### PR TITLE
[NES-190] add named Proxy contracts

### DIFF
--- a/nest/script/DeployNestContracts.s.sol
+++ b/nest/script/DeployNestContracts.s.sol
@@ -6,6 +6,8 @@ import "forge-std/Script.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
+import { AggregateTokenProxy } from "../src/proxies/AggregateTokenProxy.sol";
+import { FakeComponentTokenProxy } from "../src/proxies/FakeComponentTokenProxy.sol";
 import { AggregateToken } from "../src/AggregateToken.sol";
 import { FakeComponentToken } from "../src/FakeComponentToken.sol";
 
@@ -17,16 +19,18 @@ contract DeployNestContracts is Script {
     function run() external {
         vm.startBroadcast(ARC_ADMIN_ADDRESS);
 
-        address fakeComponentTokenProxy = Upgrades.deployUUPSProxy(
-            "FakeComponentToken.sol",
+        FakeComponentToken fakeComponentToken = new FakeComponentToken();
+        FakeComponentTokenProxy fakeComponentTokenProxy = new fakeComponentTokenProxy(
+            fakeComponentToken,
             abi.encodeCall(
                 FakeComponentToken.initialize, (ARC_ADMIN_ADDRESS, "Banana", "BAN", IERC20(USDC_ADDRESS), 18)
             )
         );
-        console.log("FakeComponentToken deployed to:", fakeComponentTokenProxy);
+        console.log("FakeComponentTokenProxy deployed to:", address(fakeComponentTokenProxy));
 
-        address aggregateTokenProxy = Upgrades.deployUUPSProxy(
-            "AggregateToken.sol",
+        AggregateToken aggregateToken = new AggregateToken();
+        AggregateTokenProxy aggregateTokenProxy = new AggregateTokenProxy(
+            aggregateToken,
             abi.encodeCall(
                 AggregateToken.initialize,
                 (
@@ -41,7 +45,7 @@ contract DeployNestContracts is Script {
                 )
             )
         );
-        console.log("AggregateToken deployed to:", aggregateTokenProxy);
+        console.log("AggregateTokenProxy deployed to:", address(aggregateTokenProxy));
 
         vm.stopBroadcast();
     }

--- a/nest/script/DeployNestContracts.s.sol
+++ b/nest/script/DeployNestContracts.s.sol
@@ -4,12 +4,11 @@ pragma solidity ^0.8.25;
 import "forge-std/Script.sol";
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { Upgrades } from "openzeppelin-foundry-upgrades/Upgrades.sol";
 
-import { AggregateTokenProxy } from "../src/proxies/AggregateTokenProxy.sol";
-import { FakeComponentTokenProxy } from "../src/proxies/FakeComponentTokenProxy.sol";
 import { AggregateToken } from "../src/AggregateToken.sol";
 import { FakeComponentToken } from "../src/FakeComponentToken.sol";
+import { AggregateTokenProxy } from "../src/proxies/AggregateTokenProxy.sol";
+import { FakeComponentTokenProxy } from "../src/proxies/FakeComponentTokenProxy.sol";
 
 contract DeployNestContracts is Script {
 
@@ -20,8 +19,8 @@ contract DeployNestContracts is Script {
         vm.startBroadcast(ARC_ADMIN_ADDRESS);
 
         FakeComponentToken fakeComponentToken = new FakeComponentToken();
-        FakeComponentTokenProxy fakeComponentTokenProxy = new fakeComponentTokenProxy(
-            fakeComponentToken,
+        FakeComponentTokenProxy fakeComponentTokenProxy = new FakeComponentTokenProxy(
+            address(fakeComponentToken),
             abi.encodeCall(
                 FakeComponentToken.initialize, (ARC_ADMIN_ADDRESS, "Banana", "BAN", IERC20(USDC_ADDRESS), 18)
             )
@@ -30,14 +29,14 @@ contract DeployNestContracts is Script {
 
         AggregateToken aggregateToken = new AggregateToken();
         AggregateTokenProxy aggregateTokenProxy = new AggregateTokenProxy(
-            aggregateToken,
+            address(aggregateToken),
             abi.encodeCall(
                 AggregateToken.initialize,
                 (
                     ARC_ADMIN_ADDRESS,
                     "Apple",
                     "AAPL",
-                    IERC20(USDC_ADDRESS),
+                    USDC_ADDRESS,
                     18,
                     15e17,
                     12e17,

--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -141,7 +141,7 @@ contract AggregateToken is
      * @param owner Address of the owner of the AggregateToken
      * @param name Name of the AggregateToken
      * @param symbol Symbol of the AggregateToken
-     * @param currencyToken CurrencyToken used to mint and burn the AggregateToken
+     * @param currencyAddress Address of the CurrencyToken used to mint and burn the AggregateToken
      * @param decimals_ Number of decimals of the AggregateToken
      * @param askPrice Price at which users can buy the AggregateToken using CurrencyToken, times the base
      * @param bidPrice Price at which users can sell the AggregateToken to receive CurrencyToken, times the base
@@ -151,7 +151,7 @@ contract AggregateToken is
         address owner,
         string memory name,
         string memory symbol,
-        IERC20 currencyToken,
+        address currencyAddress,
         uint8 decimals_,
         uint256 askPrice,
         uint256 bidPrice,
@@ -165,9 +165,9 @@ contract AggregateToken is
         _grantRole(UPGRADER_ROLE, owner);
 
         AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        $.componentTokenMap[currencyToken] = true;
-        $.componentTokenList.push(currencyToken);
-        $.currencyToken = currencyToken;
+        $.componentTokenMap[IComponentToken(currencyAddress)] = true;
+        $.componentTokenList.push(IComponentToken(currencyAddress));
+        $.currencyToken = IERC20(currencyAddress);
         $.decimals = decimals_;
         $.askPrice = askPrice;
         $.bidPrice = bidPrice;

--- a/nest/src/proxies/AggregateTokenProxy.sol
+++ b/nest/src/proxies/AggregateTokenProxy.sol
@@ -9,5 +9,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  * @notice Proxy contract for the AggregateToken
  */
 contract AggregateTokenProxy is ERC1967Proxy {
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
 }

--- a/nest/src/proxies/AggregateTokenProxy.sol
+++ b/nest/src/proxies/AggregateTokenProxy.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * @title AggregateTokenProxy
+ * @author Eugene Y. Q. Shen
+ * @notice Proxy contract for the AggregateToken
+ */
+contract AggregateTokenProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+}

--- a/nest/src/proxies/FakeComponentTokenProxy.sol
+++ b/nest/src/proxies/FakeComponentTokenProxy.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * @title FakeComponentTokenProxy
+ * @author Eugene Y. Q. Shen
+ * @notice Proxy contract for the FakeComponentToken
+ */
+contract FakeComponentTokenProxy is ERC1967Proxy {
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+}

--- a/nest/src/proxies/FakeComponentTokenProxy.sol
+++ b/nest/src/proxies/FakeComponentTokenProxy.sol
@@ -9,5 +9,7 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  * @notice Proxy contract for the FakeComponentToken
  */
 contract FakeComponentTokenProxy is ERC1967Proxy {
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
 }


### PR DESCRIPTION
## What's new in this PR?

- Add named Proxy contracts
- Add `CurrencyToken` to initial list of `ComponentTokens` in `AggregateToken`

## Why?

What problem does this solve?
- It's hard to see which `ERC1967Proxy` contract is which in the block explorer - this names them

Why is this important?
- Readability

What's the context?
- We want the sum of the value of all `ComponentTokens` to equal the value of circulating `AggregateTokens`, this is only possible if the `CurrencyToken` is also a `ComponentToken`