### PR TITLE
[CHAIN-47] remove openzeppelin-foundry-upgrades

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "nest/lib/openzeppelin-contracts-upgradeable"]
 	path = nest/lib/openzeppelin-contracts-upgradeable
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts-upgradeable
-[submodule "nest/lib/openzeppelin-foundry-upgrades"]
-	path = nest/lib/openzeppelin-foundry-upgrades
-	url = https://github.com/OpenZeppelin/openzeppelin-foundry-upgrades

--- a/foundry-template/README.md
+++ b/foundry-template/README.md
@@ -4,6 +4,5 @@ Copy this folder to start a new Foundry project, then run the following to initi
 
 ```bash
 $ forge install foundry-rs/forge-std
-$ forge install OpenZeppelin/openzeppelin-foundry-upgrades
 $ forge install OpenZeppelin/openzeppelin-contracts-upgradeable
 ```


### PR DESCRIPTION
## What's new in this PR?

Remove dependency on @OpenZeppelin/openzeppelin-foundry-upgrades.

## Why?

We are using named proxies instead of generic ERC1967 UUPS proxies.
