### PR TITLE
[CHAIN-49] minor optimizations

### DIFF
--- a/foundry-template/README.md
+++ b/foundry-template/README.md
@@ -3,8 +3,8 @@
 Copy this folder to start a new Foundry project, then run the following to initialize the project:
 
 ```bash
+$ vim README.md
+$ rm */.gitkeep
 $ forge install foundry-rs/forge-std
 $ forge install OpenZeppelin/openzeppelin-contracts-upgradeable
-$ rm */.gitkeep
-$ vim README.md
 ```

--- a/foundry-template/foundry.toml
+++ b/foundry-template/foundry.toml
@@ -8,6 +8,8 @@ ffi = true
 ast = true
 build_info = true
 extra_output = ["storageLayout"]
+optimizer = true
+optimizer_runs = 2000
 
 [fmt]
 single_line_statement_blocks = "multi"

--- a/nest/foundry.toml
+++ b/nest/foundry.toml
@@ -8,6 +8,8 @@ ffi = true
 ast = true
 build_info = true
 extra_output = ["storageLayout"]
+optimizer = true
+optimizer_runs = 2000
 
 [fmt]
 single_line_statement_blocks = "multi"

--- a/nest/script/DeployNestContracts.s.sol
+++ b/nest/script/DeployNestContracts.s.sol
@@ -8,9 +8,9 @@ import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { AggregateToken } from "../src/AggregateToken.sol";
 import { FakeComponentToken } from "../src/FakeComponentToken.sol";
 import { NestStaking } from "../src/NestStaking.sol";
-import { AggregateTokenProxy } from "../src/proxies/AggregateTokenProxy.sol";
-import { FakeComponentTokenProxy } from "../src/proxies/FakeComponentTokenProxy.sol";
-import { NestStakingProxy } from "../src/proxies/NestStakingProxy.sol";
+import { AggregateTokenProxy } from "../src/proxy/AggregateTokenProxy.sol";
+import { FakeComponentTokenProxy } from "../src/proxy/FakeComponentTokenProxy.sol";
+import { NestStakingProxy } from "../src/proxy/NestStakingProxy.sol";
 
 contract DeployNestContracts is Script {
 

--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -16,7 +16,6 @@ import { IComponentToken } from "./interfaces/IComponentToken.sol";
  * @notice ERC20 token that represents a basket of ComponentTokens
  * @dev Invariant: the total value of all AggregateTokens minted is approximately
  *   equal to the total value of all of its constituent ComponentTokens
- * @custom:oz-upgrades-from AggregateToken
  */
 contract AggregateToken is
     Initializable,
@@ -184,8 +183,7 @@ contract AggregateToken is
 
     /// @notice Number of decimals of the AggregateToken
     function decimals() public view override returns (uint8) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.decimals;
+        return _getAggregateTokenStorage().decimals;
     }
 
     // User Functions
@@ -274,8 +272,7 @@ contract AggregateToken is
         IComponentToken componentToken,
         uint256 currencyTokenAmount
     ) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        IERC20 currencyToken = $.currencyToken;
+        IERC20 currencyToken = _getAggregateTokenStorage().currencyToken;
 
         uint256 componentTokenAmount = componentToken.sell(currencyToken, currencyTokenAmount);
 
@@ -289,8 +286,7 @@ contract AggregateToken is
      * @param currencyToken New CurrencyToken
      */
     function setCurrencyToken(IERC20 currencyToken) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        $.currencyToken = currencyToken;
+        _getAggregateTokenStorage().currencyToken = currencyToken;
     }
 
     /**
@@ -298,8 +294,7 @@ contract AggregateToken is
      * @param askPrice New ask price
      */
     function setAskPrice(uint256 askPrice) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        $.askPrice = askPrice;
+        _getAggregateTokenStorage().askPrice = askPrice;
     }
 
     /**
@@ -307,8 +302,7 @@ contract AggregateToken is
      * @param bidPrice New bid price
      */
     function setBidPrice(uint256 bidPrice) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        $.bidPrice = bidPrice;
+        _getAggregateTokenStorage().bidPrice = bidPrice;
     }
 
     /**
@@ -316,34 +310,29 @@ contract AggregateToken is
      * @param tokenURI New token URI
      */
     function setTokenURI(string memory tokenURI) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        $.tokenURI = tokenURI;
+        _getAggregateTokenStorage().tokenURI = tokenURI;
     }
 
     // Getter View Functions
 
     /// @notice CurrencyToken used to mint and burn the AggregateToken
     function getCurrencyToken() public view returns (IERC20) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.currencyToken;
+        return _getAggregateTokenStorage().currencyToken;
     }
 
     /// @notice Price at which users can buy the AggregateToken using CurrencyToken, times the base
     function getAskPrice() public view returns (uint256) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.askPrice;
+        return _getAggregateTokenStorage().askPrice;
     }
 
     /// @notice Price at which users can sell the AggregateToken to receive CurrencyToken, times the base
     function getBidPrice() public view returns (uint256) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.bidPrice;
+        return _getAggregateTokenStorage().bidPrice;
     }
 
     /// @notice URI for the AggregateToken metadata
     function getTokenURI() public view returns (string memory) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.tokenURI;
+        return _getAggregateTokenStorage().tokenURI;
     }
 
     /**
@@ -351,14 +340,12 @@ contract AggregateToken is
      * @param componentToken ComponentToken to check
      */
     function getComponentToken(IComponentToken componentToken) public view returns (bool) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.componentTokenMap[componentToken];
+        return _getAggregateTokenStorage().componentTokenMap[componentToken];
     }
 
     /// @notice Get all ComponentTokens that have ever been added to the AggregateToken
     function getComponentTokenList() public view returns (IComponentToken[] memory) {
-        AggregateTokenStorage storage $ = _getAggregateTokenStorage();
-        return $.componentTokenList;
+        return _getAggregateTokenStorage().componentTokenList;
     }
 
 }

--- a/nest/src/FakeComponentToken.sol
+++ b/nest/src/FakeComponentToken.sol
@@ -14,7 +14,6 @@ import { IComponentToken } from "./interfaces/IComponentToken.sol";
  * @author Eugene Y. Q. Shen
  * @notice Fake example of a ComponentToken that could be used in an AggregateToken when testing.
  * Users can buy and sell one FakeComponentToken by exchanging it with one CurrencyToken at any time.
- * @custom:oz-upgrades-from FakeComponentToken
  */
 contract FakeComponentToken is
     Initializable,
@@ -136,8 +135,7 @@ contract FakeComponentToken is
 
     /// @notice Number of decimals of the FakeComponentToken
     function decimals() public view override returns (uint8) {
-        FakeComponentTokenStorage storage $ = _getFakeComponentTokenStorage();
-        return $.decimals;
+        return _getFakeComponentTokenStorage().decimals;
     }
 
     // User Functions
@@ -149,8 +147,7 @@ contract FakeComponentToken is
      * @param amount Amount of CurrencyToken to pay to receive the same amount of FakeComponentToken
      */
     function buy(IERC20 currencyToken_, uint256 amount) public returns (uint256) {
-        FakeComponentTokenStorage storage $ = _getFakeComponentTokenStorage();
-        IERC20 currencyToken = $.currencyToken;
+        IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
 
         if (currencyToken_ != currencyToken) {
             revert InvalidCurrencyToken(currencyToken_, currencyToken);
@@ -172,8 +169,7 @@ contract FakeComponentToken is
      * @param amount Amount of CurrencyToken to receive in exchange for the FakeComponentToken
      */
     function sell(IERC20 currencyToken_, uint256 amount) public returns (uint256) {
-        FakeComponentTokenStorage storage $ = _getFakeComponentTokenStorage();
-        IERC20 currencyToken = $.currencyToken;
+        IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
 
         if (currencyToken_ != currencyToken) {
             revert InvalidCurrencyToken(currencyToken_, currencyToken);
@@ -196,16 +192,14 @@ contract FakeComponentToken is
      * @param currencyToken New CurrencyToken
      */
     function setCurrencyToken(IERC20 currencyToken) public onlyRole(DEFAULT_ADMIN_ROLE) {
-        FakeComponentTokenStorage storage $ = _getFakeComponentTokenStorage();
-        $.currencyToken = currencyToken;
+        _getFakeComponentTokenStorage().currencyToken = currencyToken;
     }
 
     // Getter View Functions
 
     /// @notice CurrencyToken used to mint and burn the FakeComponentToken
     function getCurrencyToken() public view returns (IERC20) {
-        FakeComponentTokenStorage storage $ = _getFakeComponentTokenStorage();
-        return $.currencyToken;
+        return _getFakeComponentTokenStorage().currencyToken;
     }
 
 }

--- a/nest/src/NestStaking.sol
+++ b/nest/src/NestStaking.sol
@@ -7,13 +7,12 @@ import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils
 
 import { AggregateToken } from "./AggregateToken.sol";
 import { IAggregateToken } from "./interfaces/IAggregateToken.sol";
-import { AggregateTokenProxy } from "./proxies/AggregateTokenProxy.sol";
+import { AggregateTokenProxy } from "./proxy/AggregateTokenProxy.sol";
 
 /**
  * @title NestStaking
  * @author Eugene Y. Q. Shen
  * @notice Contract for creating AggregateTokens
- * @custom:oz-upgrades-from NestStaking
  */
 contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
 


### PR DESCRIPTION
## What's new in this PR?

- Increase optimizer runs from default 200 to 2000
- Don't assign storage to $ if only used for a single storage access
- Remove `@custom:oz-upgrades-from` tag because we're using named proxies
- Fix broken build

## Why?

What problem does this solve?
- Minor optimizations to performance

Why is this important?
What's the context?
