### PR TITLE
[CHAIN-50] support EIP-1271 signature verification

### DIFF
--- a/smart-wallets/src/SmartWallet.sol
+++ b/smart-wallets/src/SmartWallet.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/smart-wallets/src/TestWalletImplementation.sol
+++ b/smart-wallets/src/TestWalletImplementation.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 /**
  * @title TestWalletImplementation

--- a/smart-wallets/src/WalletUtils.sol
+++ b/smart-wallets/src/WalletUtils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 /**
  * @title WalletUtils

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { Address } from "@openzeppelin/contracts/utils/Address.sol";

--- a/smart-wallets/src/interfaces/ISignedOperations.sol
+++ b/smart-wallets/src/interfaces/ISignedOperations.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 interface ISignedOperations {
 

--- a/smart-wallets/src/interfaces/ISmartWallet.sol
+++ b/smart-wallets/src/interfaces/ISmartWallet.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
-interface ISmartWallet {
+import { ISignedOperations } from "./ISignedOperations.sol";
+
+interface ISmartWallet is ISignedOperations {
 
     function upgrade(address userWallet) external;
 


### PR DESCRIPTION
## What's new in this PR?

Support EIP-1271 signature verification for smart contracts that can't sign using an EOA private key.

## Why?

What problem does this solve?
Why is this important?
What's the context?
