### PR TITLE
[CHAIN-50] use try/catch for EIP-1271 signature verification

### DIFF
--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -190,6 +190,7 @@ contract SignedOperations is EIP712, WalletUtils, ISignedOperations {
 
         // Create a new scope to avoid stack too deep errors
         {
+            // Code inspired by OpenZeppelin's ERC20Permit.sol
             bytes32 structHash = keccak256(
                 abi.encode(SIGNED_OPERATIONS_TYPEHASH, targets, calls, values, nonce, nonceDependency, expiresAt)
             );

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -200,14 +200,13 @@ contract SignedOperations is EIP712, WalletUtils, ISignedOperations {
                 if (magicValue != MAGICVALUE) {
                     revert InvalidSigner(nonce, msg.sender);
                 }
-                $.nonces[nonce] = 1;
             } catch {
                 address signer = ECDSA.recover(hash, v, r, s);
                 if (signer != address(this)) {
                     revert InvalidSigner(nonce, signer);
                 }
-                $.nonces[nonce] = 1;
             }
+            $.nonces[nonce] = 1;
         }
 
         for (uint256 i = 0; i < length; i++) {

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import { EIP712 } from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -202,9 +202,7 @@ contract SignedOperations is EIP712, WalletUtils, ISignedOperations {
                 }
                 $.nonces[nonce] = 1;
             } catch {
-                // Code inspired by OpenZeppelin's ERC20Permit.sol
                 address signer = ECDSA.recover(hash, v, r, s);
-
                 if (signer != address(this)) {
                     revert InvalidSigner(nonce, signer);
                 }


### PR DESCRIPTION
## What's new in this PR?

Try to call `isValidSignature` first and fail to do so when the SignedOperations are signed by an EOA.

## Why?

What problem does this solve?
Why is this important?
What's the context?
