### PR TITLE
[CHAIN-49] add constants so named proxies have different bytecode

### DIFF
--- a/nest/src/proxy/AggregateTokenProxy.sol
+++ b/nest/src/proxy/AggregateTokenProxy.sol
@@ -10,8 +10,12 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract AggregateTokenProxy is ERC1967Proxy {
 
-    bytes32 private constant PROXY_NAME = keccak256("AggregateTokenProxy");
+    /// @notice Name of the proxy, used to ensure each named proxy has unique bytecode
+    bytes32 public constant PROXY_NAME = keccak256("AggregateTokenProxy");
 
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
+    /// @dev Fallback function to silence compiler warnings
+    receive() external payable { }
 
 }

--- a/nest/src/proxy/AggregateTokenProxy.sol
+++ b/nest/src/proxy/AggregateTokenProxy.sol
@@ -10,6 +10,8 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract AggregateTokenProxy is ERC1967Proxy {
 
+    bytes32 private constant PROXY_NAME = keccak256("AggregateTokenProxy");
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
 
 }

--- a/nest/src/proxy/FakeComponentTokenProxy.sol
+++ b/nest/src/proxy/FakeComponentTokenProxy.sol
@@ -10,6 +10,8 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract FakeComponentTokenProxy is ERC1967Proxy {
 
+    bytes32 private constant PROXY_NAME = keccak256("FakeComponentTokenProxy");
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
 
 }

--- a/nest/src/proxy/FakeComponentTokenProxy.sol
+++ b/nest/src/proxy/FakeComponentTokenProxy.sol
@@ -10,8 +10,12 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract FakeComponentTokenProxy is ERC1967Proxy {
 
-    bytes32 private constant PROXY_NAME = keccak256("FakeComponentTokenProxy");
+    /// @notice Name of the proxy, used to ensure each named proxy has unique bytecode
+    bytes32 public constant PROXY_NAME = keccak256("FakeComponentTokenProxy");
 
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
+    /// @dev Fallback function to silence compiler warnings
+    receive() external payable { }
 
 }

--- a/nest/src/proxy/NestStakingProxy.sol
+++ b/nest/src/proxy/NestStakingProxy.sol
@@ -10,8 +10,12 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract NestStakingProxy is ERC1967Proxy {
 
-    bytes32 private constant PROXY_NAME = keccak256("NestStakingProxy");
+    /// @notice Name of the proxy, used to ensure each named proxy has unique bytecode
+    bytes32 public constant PROXY_NAME = keccak256("NestStakingProxy");
 
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
+    /// @dev Fallback function to silence compiler warnings
+    receive() external payable { }
 
 }

--- a/nest/src/proxy/NestStakingProxy.sol
+++ b/nest/src/proxy/NestStakingProxy.sol
@@ -10,6 +10,8 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract NestStakingProxy is ERC1967Proxy {
 
+    bytes32 private constant PROXY_NAME = keccak256("NestStakingProxy");
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
 
 }

--- a/p/src/proxy/PProxy.sol
+++ b/p/src/proxy/PProxy.sol
@@ -10,6 +10,8 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract PProxy is ERC1967Proxy {
 
+    bytes32 private constant PROXY_NAME = keccak256("PProxy");
+
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
 
 }

--- a/p/src/proxy/PProxy.sol
+++ b/p/src/proxy/PProxy.sol
@@ -10,8 +10,12 @@ import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy
  */
 contract PProxy is ERC1967Proxy {
 
-    bytes32 private constant PROXY_NAME = keccak256("PProxy");
+    /// @notice Name of the proxy, used to ensure each named proxy has unique bytecode
+    bytes32 public constant PROXY_NAME = keccak256("PProxy");
 
     constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
+    /// @dev Fallback function to silence compiler warnings
+    receive() external payable { }
 
 }


### PR DESCRIPTION
## What's new in this PR?

Add public constants in each named proxy.

## Why?

What problem does this solve?
- Right now, all named proxies have the same bytecode, so they all show up as `AggregateTokenProxy` in contract verification systems.

Why is this important?
- It's very confusing to interact with what seems to be an `AggregateTokenProxy` when it actually points to a `ComponentToken` instead.

What's the context?
