### PR TITLE
[CHAIN-49] minor fixes to existing contracts

### DIFF
--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -58,7 +58,7 @@ contract AggregateToken is
     // Constants
 
     /// @notice Role for the upgrader of the AggregateToken
-    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADE_ROLE");
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
     // Base that is used to divide all price inputs in order to represent e.g. 1.000001 as 1000001e12
     uint256 private constant _BASE = 1e18;
@@ -88,25 +88,25 @@ contract AggregateToken is
     );
 
     /**
-     * @notice Emitted when the admin buys ComponentToken using CurrencyToken
-     * @param admin Address of the admin who bought the ComponentToken
+     * @notice Emitted when the owner buys ComponentToken using CurrencyToken
+     * @param owner Address of the owner who bought the ComponentToken
      * @param currencyToken CurrencyToken used to buy the ComponentToken
      * @param currencyTokenAmount Amount of CurrencyToken paid
      * @param componentTokenAmount Amount of ComponentToken received
      */
     event ComponentTokenBought(
-        address indexed admin, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
+        address indexed owner, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
     );
 
     /**
-     * @notice Emitted when the admin sells ComponentToken to receive CurrencyToken
-     * @param admin Address of the admin who sold the ComponentToken
+     * @notice Emitted when the owner sells ComponentToken to receive CurrencyToken
+     * @param owner Address of the owner who sold the ComponentToken
      * @param currencyToken CurrencyToken received in exchange for the ComponentToken
      * @param currencyTokenAmount Amount of CurrencyToken received
      * @param componentTokenAmount Amount of ComponentToken sold
      */
     event ComponentTokenSold(
-        address indexed admin, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
+        address indexed owner, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
     );
 
     // Errors
@@ -283,6 +283,7 @@ contract AggregateToken is
 
     /**
      * @notice Set the CurrencyToken used to mint and burn the AggregateToken
+     * @dev Only the owner can call this setter
      * @param currencyToken New CurrencyToken
      */
     function setCurrencyToken(IERC20 currencyToken) public onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -291,6 +292,7 @@ contract AggregateToken is
 
     /**
      * @notice Set the price at which users can buy the AggregateToken using CurrencyToken
+     * @dev Only the owner can call this setter
      * @param askPrice New ask price
      */
     function setAskPrice(uint256 askPrice) public onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -299,6 +301,7 @@ contract AggregateToken is
 
     /**
      * @notice Set the price at which users can sell the AggregateToken to receive CurrencyToken
+     * @dev Only the owner can call this setter
      * @param bidPrice New bid price
      */
     function setBidPrice(uint256 bidPrice) public onlyRole(DEFAULT_ADMIN_ROLE) {
@@ -307,6 +310,7 @@ contract AggregateToken is
 
     /**
      * @notice Set the URI for the AggregateToken metadata
+     * @dev Only the owner can call this setter
      * @param tokenURI New token URI
      */
     function setTokenURI(string memory tokenURI) public onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -112,7 +112,7 @@ contract AggregateToken is
     // Errors
 
     /**
-     * @notice Indicates a failure because the given CurrencyToken does not match actual CurrencyToken
+     * @notice Indicates a failure because the given CurrencyToken does not match the actual CurrencyToken
      * @param invalidCurrencyToken CurrencyToken that does not match the actual CurrencyToken
      * @param currencyToken Actual CurrencyToken used to mint and burn the AggregateToken
      */

--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -19,9 +19,9 @@ import { IComponentToken } from "./interfaces/IComponentToken.sol";
  */
 contract AggregateToken is
     Initializable,
+    ERC20Upgradeable,
     AccessControlUpgradeable,
     UUPSUpgradeable,
-    ERC20Upgradeable,
     IAggregateToken
 {
 
@@ -134,6 +134,14 @@ contract AggregateToken is
     error UserCurrencyTokenInsufficientBalance(IERC20 currencyToken, address user, uint256 amount);
 
     // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Initialize the AggregateToken

--- a/nest/src/FakeComponentToken.sol
+++ b/nest/src/FakeComponentToken.sol
@@ -17,9 +17,9 @@ import { IComponentToken } from "./interfaces/IComponentToken.sol";
  */
 contract FakeComponentToken is
     Initializable,
+    ERC20Upgradeable,
     AccessControlUpgradeable,
     UUPSUpgradeable,
-    ERC20Upgradeable,
     IComponentToken
 {
 
@@ -97,6 +97,14 @@ contract FakeComponentToken is
     error UserCurrencyTokenInsufficientBalance(IERC20 currencyToken, address user, uint256 amount);
 
     // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
 
     /**
      * @notice Initialize the FakeComponentToken

--- a/nest/src/NestStaking.sol
+++ b/nest/src/NestStaking.sol
@@ -64,7 +64,7 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
      * @param askPrice Price at which users can buy the AggregateToken using CurrencyToken, times the base
      * @param bidPrice Price at which users can sell the AggregateToken to receive CurrencyToken, times the base
      * @param tokenURI URI of the AggregateToken metadata
-     * @return address Address of the new AggregateToken
+     * @return aggregateTokenProxyAddress Address of the new AggregateTokenProxy
      */
     function createAggregateToken(
         address owner,
@@ -75,7 +75,7 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
         uint256 askPrice,
         uint256 bidPrice,
         string memory tokenURI
-    ) public returns (address) {
+    ) public returns (address aggregateTokenProxyAddress) {
         AggregateToken aggregateToken = new AggregateToken();
         AggregateTokenProxy aggregateTokenProxy = new AggregateTokenProxy(
             address(aggregateToken),
@@ -87,7 +87,7 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
 
         emit TokenCreated(msg.sender, aggregateTokenProxy);
 
-        return (address(aggregateToken));
+        return (address(aggregateTokenProxy));
     }
 
 }

--- a/nest/src/NestStaking.sol
+++ b/nest/src/NestStaking.sol
@@ -33,6 +33,14 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
     // Initializer
 
     /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
      * @notice Initialize the AggregateToken
      * @param owner Address of the owner of the AggregateToken
      */

--- a/nest/src/interfaces/IAggregateToken.sol
+++ b/nest/src/interfaces/IAggregateToken.sol
@@ -7,9 +7,9 @@ interface IAggregateToken is IComponentToken {
 
     function buyComponentToken(IComponentToken componentToken, uint256 currencyTokenAmount) external;
     function sellComponentToken(IComponentToken componentToken, uint256 currencyTokenAmount) external;
-    function getAskPrice() external view returns (uint256);
-    function getBidPrice() external view returns (uint256);
-    function getTokenURI() external view returns (string memory);
-    function getComponentTokenList() external view returns (IComponentToken[] memory);
+    function getAskPrice() external view returns (uint256 askPrice);
+    function getBidPrice() external view returns (uint256 bidPrice);
+    function getTokenURI() external view returns (string memory tokenURI);
+    function getComponentTokenList() external view returns (IComponentToken[] memory componentTokenList);
 
 }

--- a/p/src/P.sol
+++ b/p/src/P.sol
@@ -50,9 +50,9 @@ contract P is
     /**
      * @notice Initialize P
      * @dev Give all roles to the admin address passed into the constructor
-     * @param admin Address of the admin of P
+     * @param owner Address of the owner of P
      */
-    function initialize(address admin) public initializer {
+    function initialize(address owner) public initializer {
         __ERC20_init("Plume", "P");
         __ERC20Burnable_init();
         __ERC20Pausable_init();
@@ -60,12 +60,12 @@ contract P is
         __UUPSUpgradeable_init();
         __ERC20Permit_init("Plume");
 
-        _grantRole(DEFAULT_ADMIN_ROLE, admin);
-        _grantRole(ADMIN_ROLE, admin);
-        _grantRole(MINTER_ROLE, admin);
-        _grantRole(BURNER_ROLE, admin);
-        _grantRole(PAUSER_ROLE, admin);
-        _grantRole(UPGRADER_ROLE, admin);
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+        _grantRole(ADMIN_ROLE, owner);
+        _grantRole(MINTER_ROLE, owner);
+        _grantRole(BURNER_ROLE, owner);
+        _grantRole(PAUSER_ROLE, owner);
+        _grantRole(UPGRADER_ROLE, owner);
     }
 
     // Override Functions
@@ -77,7 +77,7 @@ contract P is
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
 
     /**
-     * @notice Update the balance of `from` and `to` before and after token transfer
+     * @notice Update the balance of `from` and `to` after token transfer
      * @param from Address to transfer tokens from
      * @param to Address to transfer tokens to
      * @param value Amount of tokens to transfer

--- a/p/src/P.sol
+++ b/p/src/P.sol
@@ -19,10 +19,10 @@ import { ERC20PermitUpgradeable } from
  */
 contract P is
     Initializable,
-    AccessControlUpgradeable,
     ERC20Upgradeable,
     ERC20BurnableUpgradeable,
     ERC20PausableUpgradeable,
+    AccessControlUpgradeable,
     ERC20PermitUpgradeable,
     UUPSUpgradeable
 {
@@ -42,7 +42,10 @@ contract P is
 
     // Initializer
 
-    /// @custom:oz-upgrades-unsafe-allow constructor
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
     constructor() {
         _disableInitializers();
     }
@@ -57,8 +60,8 @@ contract P is
         __ERC20Burnable_init();
         __ERC20Pausable_init();
         __AccessControl_init();
-        __UUPSUpgradeable_init();
         __ERC20Permit_init("Plume");
+        __UUPSUpgradeable_init();
 
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
         _grantRole(ADMIN_ROLE, owner);

--- a/smart-wallets/src/SmartWallet.sol
+++ b/smart-wallets/src/SmartWallet.sol
@@ -5,10 +5,8 @@ import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import { WalletUtils } from "./WalletUtils.sol";
-
 import { AssetVault } from "./extensions/AssetVault.sol";
 import { SignedOperations } from "./extensions/SignedOperations.sol";
-
 import { IAssetVault } from "./interfaces/IAssetVault.sol";
 import { ISmartWallet } from "./interfaces/ISmartWallet.sol";
 

--- a/smart-wallets/src/SmartWallet.sol
+++ b/smart-wallets/src/SmartWallet.sol
@@ -2,12 +2,11 @@
 pragma solidity ^0.8.25;
 
 import { Proxy } from "@openzeppelin/contracts/proxy/Proxy.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 import { WalletUtils } from "./WalletUtils.sol";
 import { AssetVault } from "./extensions/AssetVault.sol";
 import { SignedOperations } from "./extensions/SignedOperations.sol";
-import { IAssetVault } from "./interfaces/IAssetVault.sol";
 import { ISmartWallet } from "./interfaces/ISmartWallet.sol";
 
 /**
@@ -76,7 +75,7 @@ contract SmartWallet is Proxy, WalletUtils, SignedOperations, ISmartWallet {
     }
 
     /// @notice AssetVault associated with the smart wallet
-    function getAssetVault() external view returns (IAssetVault assetVault) {
+    function getAssetVault() external view returns (AssetVault assetVault) {
         return _getSmartWalletStorage().assetVault;
     }
 
@@ -84,7 +83,7 @@ contract SmartWallet is Proxy, WalletUtils, SignedOperations, ISmartWallet {
      * @notice Get the number of AssetTokens that are currently locked in the AssetVault
      * @param assetToken AssetToken from which the yield is to be redistributed
      */
-    function getBalanceLocked(IERC20 assetToken) public view returns (uint256 balanceLocked) {
+    function getBalanceLocked(ERC20 assetToken) public view returns (uint256 balanceLocked) {
         return _getSmartWalletStorage().assetVault.getBalanceLocked(assetToken);
     }
 

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -26,7 +26,7 @@ contract SignedOperations is EIP712, WalletUtils, ISignedOperations {
          *   of SignedOperations should be executed. The value is 1 if the nonce is used,
          *   and 0 otherwise. We store a uint256 word instead of a bool bit for efficiency.
          */
-        mapping(bytes32 nonce => uint256) nonces;
+        mapping(bytes32 nonce => uint256 used) nonces;
     }
 
     // keccak256(abi.encode(uint256(keccak256("plume.storage.SignedOperations")) - 1)) & ~bytes32(uint256(0xff))

--- a/smart-wallets/src/extensions/SignedOperations.sol
+++ b/smart-wallets/src/extensions/SignedOperations.sol
@@ -119,9 +119,9 @@ contract SignedOperations is EIP712, WalletUtils, ISignedOperations {
     /**
      * @notice Check if a nonce has been used before
      * @param nonce Nonce to check
-     * @return True if the nonce has been used before, false otherwise
+     * @return used True if the nonce has been used before, false otherwise
      */
-    function isNonceUsed(bytes32 nonce) public view returns (bool) {
+    function isNonceUsed(bytes32 nonce) public view returns (bool used) {
         return _getSignedOperationsStorage().nonces[nonce] != 0;
     }
 

--- a/smart-wallets/src/interfaces/IAssetVault.sol
+++ b/smart-wallets/src/interfaces/IAssetVault.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.25;
+pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/smart-wallets/src/interfaces/ISmartWallet.sol
+++ b/smart-wallets/src/interfaces/ISmartWallet.sol
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
-import { IAssetVault } from "./IAssetVault.sol";
+import { AssetVault } from "../extensions/AssetVault.sol";
 import { ISignedOperations } from "./ISignedOperations.sol";
 
 interface ISmartWallet is ISignedOperations {
 
     function deployAssetVault() external;
-    function getAssetVault() external view returns (IAssetVault assetVault);
-    function getBalanceLocked(IERC20 assetToken) external view returns (uint256 balanceLocked);
+    function getAssetVault() external view returns (AssetVault assetVault);
+    function getBalanceLocked(ERC20 assetToken) external view returns (uint256 balanceLocked);
     function upgrade(address userWallet) external;
 
 }


### PR DESCRIPTION
## What's new in this PR?

- Move order of OpenZeppelin initializers to match recommended order in the OpenZeppelin Contracts Wizard
- Call `_disableInitializers` in constructors of all upgradeable contracts
- Add named parameters to mappings
- Add named returns to interfaces, function signatures, and natspecs
- Rename `admin` to `owner` everywhere and comment in natspecs for `onlyRole` functions
- Rename `yieldToken` to `currencyToken` in `AssetVault.sol`
- Remove unnecessary imports
- Use actual types rather than interface types
- Unpin Solidity version from `0.8.25` and allow any patch version within `0.8`
- Fix typo in `UPGRADE_ROLE` -> `UPGRADER_ROLE` and various grammar errors
- Bugfix in `NestStaking.sol` to return the address of the proxy rather than the implementation

## Why?

What problem does this solve?
Why is this important?
What's the context?
