### PR TITLE
[NES-203] stub out view functions for AggregateToken yield

### DIFF
--- a/nest/src/FakeComponentToken.sol
+++ b/nest/src/FakeComponentToken.sol
@@ -205,4 +205,45 @@ contract FakeComponentToken is
         return _getFakeComponentTokenStorage().currencyToken;
     }
 
+    /// @notice Total yield distributed to all FakeComponentTokens for all users
+    function totalYield() public view returns (uint256 amount) {
+        return 6;
+    }
+
+    /// @notice Claimed yield across all FakeComponentTokens for all users
+    function claimedYield() public view returns (uint256 amount) {
+        return 4;
+    }
+
+    /// @notice Unclaimed yield across all FakeComponentTokens for all users
+    function unclaimedYield() external view returns (uint256 amount) {
+        return totalYield() - claimedYield();
+    }
+
+    /**
+     * @notice Total yield distributed to a specific user
+     * @param user Address of the user for which to get the total yield
+     * @return amount Total yield distributed to the user
+     */
+    function totalYield(address user) public view returns (uint256 amount) {
+        return 3;
+    }
+
+    /**
+     * @notice Amount of yield that a specific user has claimed
+     * @param user Address of the user for which to get the claimed yield
+     * @return amount Amount of yield that the user has claimed
+     */
+    function claimedYield(address user) public view returns (uint256 amount) {
+        return 2;
+    }
+
+    /**
+     * @notice Amount of yield that a specific user has not yet claimed
+     * @param user Address of the user for which to get the unclaimed yield
+     * @return amount Amount of yield that the user has not yet claimed
+     */
+    function unclaimedYield(address user) external view returns (uint256 amount) {
+        return totalYield(user) - claimedYield(user);
+    }
 }

--- a/nest/src/NestStaking.sol
+++ b/nest/src/NestStaking.sol
@@ -134,11 +134,12 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
         if (!$.isFeatured[aggregateToken]) {
             revert TokenNotFeatured(aggregateToken);
         }
-        uint256 length = $.featuredList.length;
+        IAggregateToken[] storage featuredList = $.featuredList;
+        uint256 length = featuredList.length;
         for (uint256 i = 0; i < length; ++i) {
-            if ($.featuredList[i] == aggregateToken) {
-                $.featuredList[i] = $.featuredList[length - 1];
-                $.featuredList.pop();
+            if (featuredList[i] == aggregateToken) {
+                featuredList[i] = featuredList[length - 1];
+                featuredList.pop();
                 break;
             }
         }

--- a/nest/src/interfaces/IComponentToken.sol
+++ b/nest/src/interfaces/IComponentToken.sol
@@ -7,5 +7,11 @@ interface IComponentToken is IERC20 {
 
     function buy(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
     function sell(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
+    function totalYield() external view returns (uint256 amount);
+    function claimedYield() external view returns (uint256 amount);
+    function unclaimedYield() external view returns (uint256 amount);
+    function totalYield(address user) external view returns (uint256 amount);
+    function claimedYield(address user) external view returns (uint256 amount);
+    function unclaimedYield(address user) external view returns (uint256 amount);
 
 }

--- a/smart-wallets/src/token/AssetToken.sol
+++ b/smart-wallets/src/token/AssetToken.sol
@@ -207,11 +207,13 @@ contract AssetToken is WalletUtils, YieldDistributionToken, IAssetToken {
             if (!$.isWhitelisted[user]) {
                 revert AddressNotWhitelisted(user);
             }
-            uint256 length = $.whitelist.length;
+
+            address[] storage whitelist = $.whitelist;
+            uint256 length = whitelist.length;
             for (uint256 i = 0; i < length; ++i) {
-                if ($.whitelist[i] == user) {
-                    $.whitelist[i] = $.whitelist[length - 1];
-                    $.whitelist.pop();
+                if (whitelist[i] == user) {
+                    whitelist[i] = whitelist[length - 1];
+                    whitelist.pop();
                     break;
                 }
             }
@@ -314,9 +316,10 @@ contract AssetToken is WalletUtils, YieldDistributionToken, IAssetToken {
     /// @notice Claimed yield across all AssetTokens for all users
     function claimedYield() public view returns (uint256 amount) {
         AssetTokenStorage storage $ = _getAssetTokenStorage();
-        uint256 length = $.whitelist.length;
+        address[] storage whitelist = $.whitelist;
+        uint256 length = whitelist.length;
         for (uint256 i = 0; i < length; ++i) {
-            amount += _getYieldDistributionTokenStorage().yieldWithdrawn[$.whitelist[i]];
+            amount += _getYieldDistributionTokenStorage().yieldWithdrawn[whitelist[i]];
         }
     }
 


### PR DESCRIPTION
## What's new in this PR?

Stub out view functions for `totalYield`, `claimedYield`, and `unclaimedYield` for individual users and all users together in the `AggregateToken` and `FakeComponentToken`.

Also remove the ability to remove `ComponentTokens` from the `AggregateToken`, so that `totalYield` includes all `ComponentTokens` that were ever added to the `AggregateToken`.

Also refactor `for` loops so they don't access storage every single iteration.

## Why?

What problem does this solve?
Why is this important?
What's the context?
