### PR TITLE
[NES-219] implement claimYield and version

### DIFF
--- a/nest/src/NestStaking.sol
+++ b/nest/src/NestStaking.sol
@@ -39,6 +39,8 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
 
     // Constants
 
+    /// @notice Role for the admin of the Nest Staking protocol
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
     /// @notice Role for the upgrader of the Nest Staking protocol
     bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
 
@@ -114,7 +116,7 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
      * @dev Only the owner can call this function
      * @param aggregateToken AggregateToken to be featured
      */
-    function featureToken(IAggregateToken aggregateToken) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function featureToken(IAggregateToken aggregateToken) external onlyRole(ADMIN_ROLE) {
         NestStakingStorage storage $ = _getNestStakingStorage();
         if ($.isFeatured[aggregateToken]) {
             revert TokenAlreadyFeatured(aggregateToken);
@@ -129,7 +131,7 @@ contract NestStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable
      * @dev Only the owner can call this function
      * @param aggregateToken AggregateToken to be unfeatured
      */
-    function unfeatureToken(IAggregateToken aggregateToken) external onlyRole(DEFAULT_ADMIN_ROLE) {
+    function unfeatureToken(IAggregateToken aggregateToken) external onlyRole(ADMIN_ROLE) {
         NestStakingStorage storage $ = _getNestStakingStorage();
         if (!$.isFeatured[aggregateToken]) {
             revert TokenNotFeatured(aggregateToken);

--- a/nest/src/interfaces/IComponentToken.sol
+++ b/nest/src/interfaces/IComponentToken.sol
@@ -7,6 +7,10 @@ interface IComponentToken is IERC20 {
 
     function buy(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
     function sell(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
+    function claimYield(address user) external returns (uint256 amount);
+
+    function getVersion() external view returns (uint256 version);
+    function getCurrencyToken() external view returns (IERC20 currencyToken);
     function totalYield() external view returns (uint256 amount);
     function claimedYield() external view returns (uint256 amount);
     function unclaimedYield() external view returns (uint256 amount);


### PR DESCRIPTION
## What's new in this PR?

Implement `claimYield` and `version` on both the `FakeComponentToken` and `AggregateToken`, to properly implement the interface described in https://plume-network.notion.site/Component-Token-Interface-10bf73754f8e8087993ae2a3f06407cf.

Also use `ADMIN_ROLE` rather than `DEFAULT_ADMIN_ROLE` for all admin functions.

## Why?

What problem does this solve?
Why is this important?
What's the context?
