### PR TITLE
[CHAIN-56] emit event when upgrading WalletFactory

### DIFF
--- a/smart-wallets/src/WalletFactory.sol
+++ b/smart-wallets/src/WalletFactory.sol
@@ -21,7 +21,7 @@ contract WalletFactory is Ownable {
 
     /**
      * @notice Emitted when the SmartWallet implementation is upgraded
-     * @param smartWallet New SmartWallet implementation
+     * @param smartWallet_ New SmartWallet implementation
      */
     event Upgraded(ISmartWallet smartWallet_);
 

--- a/smart-wallets/src/WalletFactory.sol
+++ b/smart-wallets/src/WalletFactory.sol
@@ -20,6 +20,12 @@ contract WalletFactory is Ownable {
     ISmartWallet public smartWallet;
 
     /**
+     * @notice Emitted when the SmartWallet implementation is upgraded
+     * @param smartWallet New SmartWallet implementation
+     */
+    event Upgraded(ISmartWallet smartWallet_);
+
+    /**
      * @notice Construct the WalletFactory
      * @param owner_ Address of the owner of the WalletFactory
      * @param smartWallet_ Initial SmartWallet implementation
@@ -36,6 +42,7 @@ contract WalletFactory is Ownable {
      */
     function upgrade(ISmartWallet smartWallet_) public onlyOwner {
         smartWallet = smartWallet_;
+        emit Upgraded(smartWallet_);
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

Emit an `Upgraded` event whenever the `WalletFactory` is upgraded by the Plume multisig.

## Why?

What problem does this solve?
Why is this important?
What's the context?
