### PR TITLE
[NES-199] create sample implementations of the ComponentToken interface

### DIFF
--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -344,10 +344,10 @@ contract AggregateToken is
 
         IERC20 currencyToken = $.currencyToken;
         currencyToken.approve(address(componentToken), currencyTokenAmount);
-        uint256 componentTokenAmount = componentToken.buy(currencyToken, currencyTokenAmount);
+        componentToken.executeBuy(address(this), 0, currencyTokenAmount, 0);
         componentToken.approve(address(componentToken), 0);
 
-        emit ComponentTokenBought(msg.sender, $.currencyToken, currencyTokenAmount, componentTokenAmount);
+        emit ComponentTokenBought(msg.sender, $.currencyToken, currencyTokenAmount, 0);
     }
 
     /**
@@ -363,9 +363,9 @@ contract AggregateToken is
     ) public onlyRole(ADMIN_ROLE) {
         IERC20 currencyToken = _getAggregateTokenStorage().currencyToken;
 
-        uint256 componentTokenAmount = componentToken.sell(currencyToken, currencyTokenAmount);
+        componentToken.executeSell(address(this), 0, currencyTokenAmount, 0);
 
-        emit ComponentTokenSold(msg.sender, currencyToken, currencyTokenAmount, componentTokenAmount);
+        emit ComponentTokenSold(msg.sender, currencyToken, currencyTokenAmount, 0);
     }
 
     // Admin Setter Functions

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -84,9 +84,7 @@ abstract contract ComponentToken is
      * @param currencyToken CurrencyToken to be used to buy the ComponentToken
      * @param currencyTokenAmount Amount of CurrencyToken offered to be paid
      */
-    event BuyRequested(
-        address indexed user, IERC20 indexed currencyToken, uint256 currencyTokenAmount
-    );
+    event BuyRequested(address indexed user, IERC20 indexed currencyToken, uint256 currencyTokenAmount);
 
     /**
      * @notice Emitted when a user requests to sell ComponentToken to receive CurrencyToken
@@ -94,9 +92,7 @@ abstract contract ComponentToken is
      * @param currencyToken CurrencyToken to be received in exchange for the ComponentToken
      * @param componentTokenAmount Amount of ComponentToken offered to be sold
      */
-    event SellRequested(
-        address indexed user, IERC20 indexed currencyToken, uint256 componentTokenAmount
-    );
+    event SellRequested(address indexed user, IERC20 indexed currencyToken, uint256 componentTokenAmount);
 
     /**
      * @notice Emitted when a user buys ComponentToken using CurrencyToken
@@ -252,7 +248,12 @@ abstract contract ComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public virtual {
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public virtual {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         if (requestId >= $.requests.length) {
             revert InvalidRequest(requestId, 0);
@@ -286,7 +287,12 @@ abstract contract ComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to receive
      * @param componentTokenAmount Amount of ComponentToken to send
      */
-     function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public virtual {
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public virtual {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         if (requestId >= $.requests.length) {
             revert InvalidRequest(requestId, 0);
@@ -313,7 +319,7 @@ abstract contract ComponentToken is
         request.isExecuted = true;
 
         emit SellExecuted(requestor, currencyToken, currencyTokenAmount, componentTokenAmount);
-     }
+    }
 
     /**
      * @notice Claim all the remaining yield that has been accrued to a user

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -1,0 +1,416 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IComponentToken } from "./interfaces/IComponentToken.sol";
+
+/**
+ * @title ComponentToken
+ * @author Eugene Y. Q. Shen
+ * @notice Abstract contract that implements the IComponentToken interface and can be extended
+ *   with a concrete implementation that interfaces with an external real-world asset.
+ */
+abstract contract ComponentToken is
+    Initializable,
+    ERC20Upgradeable,
+    AccessControlUpgradeable,
+    UUPSUpgradeable,
+    IComponentToken
+{
+
+    // Storage
+
+    /// @notice Represents a request to buy or sell ComponentToken using CurrencyToken
+    struct Request {
+        /// @dev Unique identifier for the request
+        uint256 requestId;
+        /// @dev CurrencyTokenAmount for a buy; ComponentTokenAmount for a sell
+        uint256 amount;
+        /// @dev Address of the user or smart contract who requested the buy or sell
+        address requestor;
+        /// @dev True for a buy request; false for a sell request
+        bool isBuy;
+        /// @dev True if the request has been executed; false otherwise
+        bool isExecuted;
+    }
+
+    /// @custom:storage-location erc7201:plume.storage.ComponentToken
+    struct ComponentTokenStorage {
+        /// @dev CurrencyToken used to mint and burn the ComponentToken
+        IERC20 currencyToken;
+        /// @dev Number of decimals of the ComponentToken
+        uint8 decimals;
+        /// @dev Version of the ComponentToken interface
+        uint256 version;
+        /// @dev Requests to buy or sell ComponentToken using CurrencyToken
+        Request[] requests;
+        /// @dev Total amount of yield that has ever been accrued by all users
+        uint256 totalYieldAccrued;
+        /// @dev Total amount of yield that has ever been withdrawn by all users
+        uint256 totalYieldWithdrawn;
+        /// @dev Total amount of yield that has ever been accrued by each user
+        mapping(address user => uint256 currencyTokenAmount) yieldAccrued;
+        /// @dev Total amount of yield that has ever been withdrawn by each user
+        mapping(address user => uint256 currencyTokenAmount) yieldWithdrawn;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.ComponentToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant COMPONENT_TOKEN_STORAGE_LOCATION =
+        0x40f2ca4cf3a525ed9b1b2649f0f850db77540accc558be58ba47f8638359e800;
+
+    function _getComponentTokenStorage() internal pure returns (ComponentTokenStorage storage $) {
+        assembly {
+            $.slot := COMPONENT_TOKEN_STORAGE_LOCATION
+        }
+    }
+
+    // Constants
+
+    /// @notice Role for the admin of the ComponentToken
+    bytes32 public constant ADMIN_ROLE = keccak256("ADMIN_ROLE");
+    /// @notice Role for the upgrader of the ComponentToken
+    bytes32 public constant UPGRADER_ROLE = keccak256("UPGRADER_ROLE");
+
+    // Events
+
+    /**
+     * @notice Emitted when a user requests to buy ComponentToken using CurrencyToken
+     * @param user Address of the user who requested to buy the ComponentToken
+     * @param currencyToken CurrencyToken to be used to buy the ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken offered to be paid
+     */
+    event BuyRequested(
+        address indexed user, IERC20 indexed currencyToken, uint256 currencyTokenAmount
+    );
+
+    /**
+     * @notice Emitted when a user requests to sell ComponentToken to receive CurrencyToken
+     * @param user Address of the user who requested to sell the ComponentToken
+     * @param currencyToken CurrencyToken to be received in exchange for the ComponentToken
+     * @param componentTokenAmount Amount of ComponentToken offered to be sold
+     */
+    event SellRequested(
+        address indexed user, IERC20 indexed currencyToken, uint256 componentTokenAmount
+    );
+
+    /**
+     * @notice Emitted when a user buys ComponentToken using CurrencyToken
+     * @param user Address of the user who bought the ComponentToken
+     * @param currencyToken CurrencyToken used to buy the ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken paid
+     * @param componentTokenAmount Amount of ComponentToken received
+     */
+    event BuyExecuted(
+        address indexed user, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
+    );
+
+    /**
+     * @notice Emitted when a user sells ComponentToken to receive CurrencyToken
+     * @param user Address of the user who sold the ComponentToken
+     * @param currencyToken CurrencyToken received in exchange for the ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken received
+     * @param componentTokenAmount Amount of ComponentToken sold
+     */
+    event SellExecuted(
+        address indexed user, IERC20 indexed currencyToken, uint256 currencyTokenAmount, uint256 componentTokenAmount
+    );
+
+    /**
+     * @notice Emitted when anyone claims yield that has accrued to a user
+     * @param user Address of the user who receives the claimed yield
+     * @param currencyToken CurrencyToken used to denominate the claimed yield
+     * @param amount Amount of CurrencyToken claimed as yield
+     */
+    event YieldClaimed(address indexed user, IERC20 indexed currencyToken, uint256 amount);
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the given request ID is invalid
+     * @param invalidRequestId Request ID that is invalid
+     * @param errorType Type of error that occurred
+     *   0: Request ID does not exist
+     *   1: Request amount does not match the amount the user is trying to execute
+     *   2: Requestor is not the user trying to execute the request
+     *   3: Request is not a buy request, but the user is trying to execute a buy
+     *   4: Request is not a sell request, but the user is trying to execute a sell
+     *   5: Request has already been executed
+     */
+    error InvalidRequest(uint256 invalidRequestId, uint256 errorType);
+
+    /**
+     * @notice Indicates a failure because the given version is not higher than the current version
+     * @param invalidVersion Invalid version that is not higher than the current version
+     * @param version Current version of the ComponentToken
+     */
+    error InvalidVersion(uint256 invalidVersion, uint256 version);
+
+    /**
+     * @notice Indicates a failure because the user does not have enough CurrencyToken
+     * @param currencyToken CurrencyToken used to mint and burn the ComponentToken
+     * @param user Address of the user who is selling the CurrencyToken
+     * @param amount Amount of CurrencyToken required in the failed transfer
+     */
+    error InsufficientBalance(IERC20 currencyToken, address user, uint256 amount);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the ComponentToken
+     * @param owner Address of the owner of the ComponentToken
+     * @param name Name of the ComponentToken
+     * @param symbol Symbol of the ComponentToken
+     * @param currencyToken CurrencyToken used to mint and burn the ComponentToken
+     * @param decimals_ Number of decimals of the ComponentToken
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_
+    ) public initializer {
+        __ERC20_init(name, symbol);
+        __AccessControl_init();
+        __UUPSUpgradeable_init();
+
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+        _grantRole(ADMIN_ROLE, owner);
+        _grantRole(UPGRADER_ROLE, owner);
+
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        $.currencyToken = currencyToken;
+        $.decimals = decimals_;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Revert when `msg.sender` is not authorized to upgrade the contract
+     * @param newImplementation Address of the new implementation
+     */
+    function _authorizeUpgrade(address newImplementation) internal override(UUPSUpgradeable) onlyRole(UPGRADER_ROLE) { }
+
+    /// @notice Number of decimals of the ComponentToken
+    function decimals() public view override returns (uint8) {
+        return _getComponentTokenStorage().decimals;
+    }
+
+    // User Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        IERC20 currencyToken = $.currencyToken;
+        requestId = $.requests.length;
+
+        if (!currencyToken.transferFrom(msg.sender, address(this), currencyTokenAmount)) {
+            revert InsufficientBalance(currencyToken, msg.sender, currencyTokenAmount);
+        }
+        $.requests.push(Request(requestId, currencyTokenAmount, msg.sender, true, false));
+
+        emit BuyRequested(msg.sender, currencyToken, currencyTokenAmount);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) external returns (uint256 requestId) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        IERC20 currencyToken = $.currencyToken;
+        requestId = $.requests.length;
+
+        _burn(msg.sender, componentTokenAmount);
+        $.requests.push(Request(requestId, componentTokenAmount, msg.sender, false, false));
+
+        emit SellRequested(msg.sender, currencyToken, componentTokenAmount);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        if (requestId >= $.requests.length) {
+            revert InvalidRequest(requestId, 0);
+        }
+
+        IERC20 currencyToken = $.currencyToken;
+        Request storage request = $.requests[requestId];
+        if (request.amount != currencyTokenAmount) {
+            revert InvalidRequest(requestId, 1);
+        }
+        if (request.requestor != requestor) {
+            revert InvalidRequest(requestId, 2);
+        }
+        if (!request.isBuy) {
+            revert InvalidRequest(requestId, 3);
+        }
+        if (request.isExecuted) {
+            revert InvalidRequest(requestId, 5);
+        }
+
+        _mint(requestor, componentTokenAmount);
+        request.isExecuted = true;
+
+        emit BuyExecuted(requestor, currencyToken, currencyTokenAmount, componentTokenAmount);
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+     function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        if (requestId >= $.requests.length) {
+            revert InvalidRequest(requestId, 0);
+        }
+
+        IERC20 currencyToken = $.currencyToken;
+        Request storage request = $.requests[requestId];
+        if (request.amount != componentTokenAmount) {
+            revert InvalidRequest(requestId, 1);
+        }
+        if (request.requestor != requestor) {
+            revert InvalidRequest(requestId, 2);
+        }
+        if (request.isBuy) {
+            revert InvalidRequest(requestId, 4);
+        }
+        if (request.isExecuted) {
+            revert InvalidRequest(requestId, 5);
+        }
+
+        if (!currencyToken.transfer(requestor, currencyTokenAmount)) {
+            revert InsufficientBalance(currencyToken, requestor, currencyTokenAmount);
+        }
+        request.isExecuted = true;
+
+        emit SellExecuted(requestor, currencyToken, currencyTokenAmount, componentTokenAmount);
+     }
+
+    /**
+     * @notice Claim all the remaining yield that has been accrued to a user
+     * @dev Anyone can call this function to claim yield for any user
+     * @param user Address of the user to claim yield for
+     * @return amount Amount of CurrencyToken claimed as yield
+     */
+    function claimYield(address user) external returns (uint256 amount) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        IERC20 currencyToken = $.currencyToken;
+
+        amount = unclaimedYield(user);
+        currencyToken.transfer(user, amount);
+        $.yieldWithdrawn[user] += amount;
+        $.totalYieldWithdrawn += amount;
+
+        emit YieldClaimed(user, currencyToken, amount);
+    }
+
+    // Admin Setter Functions
+
+    /**
+     * @notice Set the version of the ComponentToken
+     * @dev Only the owner can call this setter
+     * @param version New version of the ComponentToken
+     */
+    function setVersion(uint256 version) external onlyRole(ADMIN_ROLE) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        if (version <= $.version) {
+            revert InvalidVersion(version, $.version);
+        }
+        $.version = version;
+    }
+
+    /**
+     * @notice Set the CurrencyToken used to mint and burn the ComponentToken
+     * @dev Only the owner can call this setter
+     * @param currencyToken New CurrencyToken
+     */
+    function setCurrencyToken(IERC20 currencyToken) external onlyRole(ADMIN_ROLE) {
+        _getComponentTokenStorage().currencyToken = currencyToken;
+    }
+
+    // Getter View Functions
+
+    /// @notice Returns the version of the ComponentToken interface
+    function getVersion() external view returns (uint256) {
+        return _getComponentTokenStorage().version;
+    }
+
+    /// @notice CurrencyToken used to buy and sell the ComponentToken
+    function getCurrencyToken() external view returns (IERC20) {
+        return _getComponentTokenStorage().currencyToken;
+    }
+
+    /// @notice Total yield distributed to the ComponentToken for all users
+    function totalYield() external view returns (uint256 amount) {
+        return _getComponentTokenStorage().totalYieldAccrued;
+    }
+
+    /// @notice Claimed yield across the ComponentToken for all users
+    function claimedYield() external view returns (uint256 amount) {
+        return _getComponentTokenStorage().totalYieldWithdrawn;
+    }
+
+    /// @notice Unclaimed yield across the ComponentToken for all users
+    function unclaimedYield() external view returns (uint256 amount) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        return $.totalYieldAccrued - $.totalYieldWithdrawn;
+    }
+
+    /**
+     * @notice Total yield distributed to a specific user
+     * @param user Address of the user for which to get the total yield
+     * @return amount Total yield distributed to the user
+     */
+    function totalYield(address user) external view returns (uint256 amount) {
+        return _getComponentTokenStorage().yieldAccrued[user];
+    }
+
+    /**
+     * @notice Amount of yield that a specific user has claimed
+     * @param user Address of the user for which to get the claimed yield
+     * @return amount Amount of yield that the user has claimed
+     */
+    function claimedYield(address user) external view returns (uint256 amount) {
+        return _getComponentTokenStorage().yieldWithdrawn[user];
+    }
+
+    /**
+     * @notice Amount of yield that a specific user has not yet claimed
+     * @param user Address of the user for which to get the unclaimed yield
+     * @return amount Amount of yield that the user has not yet claimed
+     */
+    function unclaimedYield(address user) public view returns (uint256 amount) {
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        return $.yieldAccrued[user] - $.yieldWithdrawn[user];
+    }
+
+}

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -216,7 +216,7 @@ abstract contract ComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @return requestId Unique identifier for the buy request
      */
-    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId) {
+    function requestBuy(uint256 currencyTokenAmount) public virtual returns (uint256 requestId) {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         IERC20 currencyToken = $.currencyToken;
         requestId = $.requests.length;
@@ -234,7 +234,7 @@ abstract contract ComponentToken is
      * @param componentTokenAmount Amount of ComponentToken to send
      * @return requestId Unique identifier for the sell request
      */
-    function requestSell(uint256 componentTokenAmount) external returns (uint256 requestId) {
+    function requestSell(uint256 componentTokenAmount) public virtual returns (uint256 requestId) {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         IERC20 currencyToken = $.currencyToken;
         requestId = $.requests.length;
@@ -252,7 +252,7 @@ abstract contract ComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external {
+    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public virtual {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         if (requestId >= $.requests.length) {
             revert InvalidRequest(requestId, 0);
@@ -286,7 +286,7 @@ abstract contract ComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to receive
      * @param componentTokenAmount Amount of ComponentToken to send
      */
-     function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external {
+     function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public virtual {
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         if (requestId >= $.requests.length) {
             revert InvalidRequest(requestId, 0);

--- a/nest/src/FakeComponentToken.sol
+++ b/nest/src/FakeComponentToken.sol
@@ -164,9 +164,9 @@ contract FakeComponentToken is
     }
 
     // User Functions
-    
-    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId) {}
-    function requestSell(uint256 currencyTokenAmount) external returns (uint256 requestId) {}
+
+    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId) { }
+    function requestSell(uint256 currencyTokenAmount) external returns (uint256 requestId) { }
 
     /**
      * @notice Executes a request to buy ComponentToken with CurrencyToken
@@ -175,7 +175,12 @@ contract FakeComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public {
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public {
         IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
         uint256 amount = currencyTokenAmount;
         if (!currencyToken.transferFrom(msg.sender, address(this), amount)) {
@@ -194,7 +199,12 @@ contract FakeComponentToken is
      * @param currencyTokenAmount Amount of CurrencyToken to receive
      * @param componentTokenAmount Amount of ComponentToken to send
      */
-    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public {
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public {
         IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
         uint256 amount = currencyTokenAmount;
         if (!currencyToken.transfer(msg.sender, amount)) {

--- a/nest/src/FakeComponentToken.sol
+++ b/nest/src/FakeComponentToken.sol
@@ -164,18 +164,20 @@ contract FakeComponentToken is
     }
 
     // User Functions
+    
+    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId) {}
+    function requestSell(uint256 currencyTokenAmount) external returns (uint256 requestId) {}
 
     /**
-     * @notice Buy FakeComponentToken using CurrencyToken
-     * @dev The user must approve the contract to spend the CurrencyToken
-     * @param currencyToken CurrencyToken used to buy the FakeComponentToken
-     * @param amount Amount of CurrencyToken to pay to receive the same amount of FakeComponentToken
-     * @return componentTokenAmount Amount of FakeComponentToken received
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function buy(IERC20 currencyToken, uint256 amount) public returns (uint256 componentTokenAmount) {
-        if (currencyToken != _getFakeComponentTokenStorage().currencyToken) {
-            revert InvalidCurrencyToken(currencyToken, _getFakeComponentTokenStorage().currencyToken);
-        }
+    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public {
+        IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
+        uint256 amount = currencyTokenAmount;
         if (!currencyToken.transferFrom(msg.sender, address(this), amount)) {
             revert UserCurrencyTokenInsufficientBalance(currencyToken, msg.sender, amount);
         }
@@ -186,15 +188,15 @@ contract FakeComponentToken is
     }
 
     /**
-     * @notice Sell FakeComponentToken to receive CurrencyToken
-     * @param currencyToken CurrencyToken received in exchange for the FakeComponentToken
-     * @param amount Amount of CurrencyToken to receive in exchange for the FakeComponentToken
-     * @return componentTokenAmount Amount of FakeComponentToken sold
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
      */
-    function sell(IERC20 currencyToken, uint256 amount) public returns (uint256 componentTokenAmount) {
-        if (currencyToken != _getFakeComponentTokenStorage().currencyToken) {
-            revert InvalidCurrencyToken(currencyToken, _getFakeComponentTokenStorage().currencyToken);
-        }
+    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public {
+        IERC20 currencyToken = _getFakeComponentTokenStorage().currencyToken;
+        uint256 amount = currencyTokenAmount;
         if (!currencyToken.transfer(msg.sender, amount)) {
             revert CurrencyTokenInsufficientBalance(currencyToken, amount);
         }

--- a/nest/src/interfaces/IAggregateToken.sol
+++ b/nest/src/interfaces/IAggregateToken.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import { IComponentToken } from "./IComponentToken.sol";
 
-interface IAggregateToken is IComponentToken {
+interface IAggregateToken {
 
     function buyComponentToken(IComponentToken componentToken, uint256 currencyTokenAmount) external;
     function sellComponentToken(IComponentToken componentToken, uint256 currencyTokenAmount) external;

--- a/nest/src/interfaces/IClaimableYieldToken.sol
+++ b/nest/src/interfaces/IClaimableYieldToken.sol
@@ -11,7 +11,7 @@ interface IClaimableYieldToken is IERC20 {
      * @param user Address of the user to claim yield for
      * @return amount Amount of CurrencyToken claimed as yield
      */
-    function claimYield(address user) public returns (uint256 amount);
+    function claimYield(address user) external returns (uint256 amount);
 
     /// @notice CurrencyToken in which both the ClaimableYieldToken and yield are denominated
     function getCurrencyToken() external view returns (IERC20 currencyToken);

--- a/nest/src/interfaces/IClaimableYieldToken.sol
+++ b/nest/src/interfaces/IClaimableYieldToken.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IClaimableYieldToken is IERC20 {
+
+    /**
+     * @notice Claim all the remaining yield that has been accrued to a user
+     * @dev Anyone can call this function to claim yield for any user
+     * @param user Address of the user to claim yield for
+     * @return amount Amount of CurrencyToken claimed as yield
+     */
+    function claimYield(address user) public returns (uint256 amount);
+
+    /// @notice CurrencyToken in which both the ClaimableYieldToken and yield are denominated
+    function getCurrencyToken() external view returns (IERC20 currencyToken);
+
+    /// @notice Total yield distributed to the ClaimableYieldToken for all users
+    function totalYield() external view returns (uint256 amount);
+
+    /// @notice Claimed yield for the ClaimableYieldToken for all users
+    function claimedYield() external view returns (uint256 amount);
+
+    /// @notice Unclaimed yield for the ClaimableYieldToken for all users
+    function unclaimedYield() external view returns (uint256 amount);
+
+    /**
+     * @notice Total yield distributed to a specific user
+     * @param user Address of the user for which to get the total yield
+     * @return amount Total yield distributed to the user
+     */
+    function totalYield(address user) external view returns (uint256 amount);
+
+    /**
+     * @notice Amount of yield that a specific user has claimed
+     * @param user Address of the user for which to get the claimed yield
+     * @return amount Amount of yield that the user has claimed
+     */
+    function claimedYield(address user) external view returns (uint256 amount);
+
+    /**
+     * @notice Amount of yield that a specific user has not yet claimed
+     * @param user Address of the user for which to get the unclaimed yield
+     * @return amount Amount of yield that the user has not yet claimed
+     */
+    function unclaimedYield(address user) external view returns (uint256 amount);
+
+}

--- a/nest/src/interfaces/IComponentToken.sol
+++ b/nest/src/interfaces/IComponentToken.sol
@@ -2,20 +2,43 @@
 pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IClaimableYieldToken } from "./IClaimableYieldToken.sol";
 
-interface IComponentToken is IERC20 {
+interface IComponentToken is IClaimableYieldToken {
 
-    function buy(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
-    function sell(IERC20 currencyToken, uint256 currencyTokenAmount) external returns (uint256 componentTokenAmount);
-    function claimYield(address user) external returns (uint256 amount);
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) external returns (uint256 requestId);
 
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) external returns (uint256 requestId);
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+
+    /// @notice Returns the version of the ComponentToken interface
     function getVersion() external view returns (uint256 version);
-    function getCurrencyToken() external view returns (IERC20 currencyToken);
-    function totalYield() external view returns (uint256 amount);
-    function claimedYield() external view returns (uint256 amount);
-    function unclaimedYield() external view returns (uint256 amount);
-    function totalYield(address user) external view returns (uint256 amount);
-    function claimedYield(address user) external view returns (uint256 amount);
-    function unclaimedYield(address user) external view returns (uint256 amount);
 
 }

--- a/nest/src/interfaces/IComponentToken.sol
+++ b/nest/src/interfaces/IComponentToken.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IClaimableYieldToken } from "./IClaimableYieldToken.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IComponentToken is IClaimableYieldToken {
 
@@ -27,7 +27,12 @@ interface IComponentToken is IClaimableYieldToken {
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
 
     /**
      * @notice Executes a request to sell ComponentToken for CurrencyToken
@@ -36,7 +41,12 @@ interface IComponentToken is IClaimableYieldToken {
      * @param currencyTokenAmount Amount of CurrencyToken to receive
      * @param componentTokenAmount Amount of ComponentToken to send
      */
-    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
 
     /// @notice Returns the version of the ComponentToken interface
     function getVersion() external view returns (uint256 version);

--- a/nest/src/token/AdapterToken.sol
+++ b/nest/src/token/AdapterToken.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IComponentToken } from "./interfaces/IComponentToken.sol";
+
+/// @notice Example of an interface for the Nest Staking contract
+interface IAggregateToken {
+    /// @notice Notify the Nest Staking contract that a buy has been executed
+    function notifyBuy(IERC20 currencyToken, IERC20 componentToken, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+    /// @notice Notify the Nest Staking contract that a sell has been executed
+    function notifySell(IERC20 currencyToken, IERC20 componentToken, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+}
+
+/// @notice Example of an interface for the external contract that manages the external asset
+interface IExternalContract {
+    /// @notice Notify the external contract that a buy has been requested
+    function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
+    /// @notice Notify the external contract that a sell has been requested
+    function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+}
+
+/**
+ * @title AdapterToken
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
+ */
+contract AdapterToken is ComponentToken {
+
+    // Storage
+
+    /// @custom:storage-location erc7201:plume.storage.AdapterToken
+    struct AdapterTokenStorage {
+        /// @dev Address of the Nest Staking contract
+        IAggregateToken nestStakingContract;
+        /// @dev Address of the external contract that manages the external asset
+        IExternalContract externalContract;
+        /// @dev Mapping from request IDs to external request UUIDs
+        mapping(uint256 requestId => bytes16 externalUuid) requestMap;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.AdapterToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ADAPTER_TOKEN_STORAGE_LOCATION =
+        0xb94ddb3268639eae8606689fcefbcb8a18c8a94fc82eefd097206f0c02fe9100;
+
+    function _getAdapterTokenStorage() private pure returns (AdapterTokenStorage storage $) {
+        assembly {
+            $.slot := ADAPTER_TOKEN_STORAGE_LOCATION
+        }
+    }
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the caller is not the authorized caller
+     * @param invalidCaller Address of the caller that is not the authorized caller
+     * @param caller Address of the authorized caller
+     */
+    error Unauthorized(address invalidCaller, address caller);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the AdapterToken
+     * @param owner Address of the owner of the AdapterToken
+     * @param name Name of the AdapterToken
+     * @param symbol Symbol of the AdapterToken
+     * @param currencyToken CurrencyToken used to mint and burn the AdapterToken
+     * @param decimals_ Number of decimals of the AdapterToken
+     * @param nestStakingContract Address of the Nest Staking contract
+     * @param externalContract Address of the external contract that manages the external asset
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_,
+        IAggregateToken nestStakingContract,
+        IExternalContract externalContract
+    ) public override(ComponentToken) initializer {
+        super.initialize(owner, name, symbol, currencyToken, decimals_);
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        $.nestStakingContract = nestStakingContract;
+        $.externalContract = externalContract;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) external override(ComponentToken) returns (uint256 requestId) {
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        if (msg.sender != $.nestStakingContract) {
+            revert Unauthorized(msg.sender, $.nestStakingContract);
+        }
+        requestId = super.requestBuy(currencyTokenAmount);
+        externalContract.requestBuy(currencyTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) external override(ComponentToken) returns (uint256 requestId) {
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        if (msg.sender != $.nestStakingContract) {
+            revert Unauthorized(msg.sender, $.nestStakingContract);
+        }
+        requestId = super.requestSell(componentTokenAmount);
+        externalContract.requestSell(componentTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external override(ComponentToken) {
+        if (requestor != $.nestStakingContract) {
+            revert Unauthorized(requestor, $.nestStakingContract);
+        }
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        if (msg.sender != $.externalContract) {
+            revert Unauthorized(msg.sender, $.externalContract);
+        }
+        super.executeBuy($.nestStakingContract, requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(_getComponentTokenStorage().currencyToken, address(this), currencyTokenAmount, componentTokenAmount);
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) external override(ComponentToken) {
+        if (requestor != $.nestStakingContract) {
+            revert Unauthorized(requestor, $.nestStakingContract);
+        }
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        if (msg.sender != $.externalContract) {
+            revert Unauthorized(msg.sender, $.externalContract);
+        }
+        super.executeSell($.nestStakingContract, requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(_getComponentTokenStorage().currencyToken, address(this), currencyTokenAmount, componentTokenAmount);
+    }
+
+    // Admin Functions
+
+    function distributeYield(address user, uint256 amount) external {
+        AdapterTokenStorage storage $ = _getAdapterTokenStorage();
+        if (msg.sender != $.nestStakingContract) {
+            revert Unauthorized(msg.sender, $.nestStakingContract);
+        }
+
+        ComponentTokenStorage storage cs = _getComponentTokenStorage();
+        cs.currencyToken.transfer(user, amount);
+        cs.yieldAccrued[user] += amount;
+    }
+
+}

--- a/nest/src/token/AdapterToken.sol
+++ b/nest/src/token/AdapterToken.sol
@@ -11,18 +11,32 @@ import { ComponentToken } from "../ComponentToken.sol";
 
 /// @notice Example of an interface for the Nest Staking contract
 interface IAggregateToken {
+
     /// @notice Notify the Nest Staking contract that a buy has been executed
-    function notifyBuy(IERC20 currencyToken, IERC20 componentToken, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+    function notifyBuy(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
     /// @notice Notify the Nest Staking contract that a sell has been executed
-    function notifySell(IERC20 currencyToken, IERC20 componentToken, uint256 currencyTokenAmount, uint256 componentTokenAmount) external;
+    function notifySell(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+
 }
 
 /// @notice Example of an interface for the external contract that manages the external asset
 interface IExternalContract {
+
     /// @notice Notify the external contract that a buy has been requested
     function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
     /// @notice Notify the external contract that a sell has been requested
     function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+
 }
 
 /**
@@ -135,7 +149,12 @@ contract AdapterToken is ComponentToken {
      * @param currencyTokenAmount Amount of CurrencyToken to send
      * @param componentTokenAmount Amount of ComponentToken to receive
      */
-    function executeBuy(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public override(ComponentToken) {
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
         AdapterTokenStorage storage $ = _getAdapterTokenStorage();
         if (msg.sender != address($.nestStakingContract)) {
             revert Unauthorized(requestor, address($.nestStakingContract));
@@ -144,7 +163,9 @@ contract AdapterToken is ComponentToken {
             revert Unauthorized(msg.sender, address($.externalContract));
         }
         super.executeBuy(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
-        $.nestStakingContract.notifyBuy(_getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
     }
 
     /**
@@ -154,7 +175,12 @@ contract AdapterToken is ComponentToken {
      * @param currencyTokenAmount Amount of CurrencyToken to receive
      * @param componentTokenAmount Amount of ComponentToken to send
      */
-    function executeSell(address requestor, uint256 requestId, uint256 currencyTokenAmount, uint256 componentTokenAmount) public override(ComponentToken) {
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
         AdapterTokenStorage storage $ = _getAdapterTokenStorage();
         if (requestor != address($.nestStakingContract)) {
             revert Unauthorized(requestor, address($.nestStakingContract));
@@ -163,7 +189,9 @@ contract AdapterToken is ComponentToken {
             revert Unauthorized(msg.sender, address($.externalContract));
         }
         super.executeSell(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
-        $.nestStakingContract.notifySell(_getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
     }
 
     // Admin Functions

--- a/nest/src/token/AnemoyToken.sol
+++ b/nest/src/token/AnemoyToken.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { ComponentToken } from "../ComponentToken.sol";
+
+/// @notice Example of an interface for the Nest Staking contract
+interface IAggregateToken {
+
+    /// @notice Notify the Nest Staking contract that a buy has been executed
+    function notifyBuy(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+    /// @notice Notify the Nest Staking contract that a sell has been executed
+    function notifySell(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+
+}
+
+/// @notice Example of an interface for the external contract that manages the external asset
+interface IExternalContract {
+
+    /// @notice Notify the external contract that a buy has been requested
+    function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
+    /// @notice Notify the external contract that a sell has been requested
+    function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+
+}
+
+/**
+ * @title AnemoyToken
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
+ */
+contract AnemoyToken is ComponentToken {
+
+    // Storage
+
+    /// @custom:storage-location erc7201:plume.storage.AnemoyToken
+    struct AnemoyTokenStorage {
+        /// @dev Address of the Nest Staking contract
+        IAggregateToken nestStakingContract;
+        /// @dev Address of the external contract that manages the external asset
+        IExternalContract externalContract;
+        /// @dev Mapping from request IDs to external request UUIDs
+        mapping(uint256 requestId => bytes16 externalUuid) requestMap;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.AnemoyToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ANEMOY_TOKEN_STORAGE_LOCATION =
+        0x3fd968f781f06a12b16a94ea1c379f12e0a9c776039f6cfa0baf37d70158ae00;
+
+    function _getAnemoyTokenStorage() private pure returns (AnemoyTokenStorage storage $) {
+        assembly {
+            $.slot := ANEMOY_TOKEN_STORAGE_LOCATION
+        }
+    }
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the caller is not the authorized caller
+     * @param invalidCaller Address of the caller that is not the authorized caller
+     * @param caller Address of the authorized caller
+     */
+    error Unauthorized(address invalidCaller, address caller);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the AnemoyToken
+     * @param owner Address of the owner of the AnemoyToken
+     * @param name Name of the AnemoyToken
+     * @param symbol Symbol of the AnemoyToken
+     * @param currencyToken CurrencyToken used to mint and burn the AnemoyToken
+     * @param decimals_ Number of decimals of the AnemoyToken
+     * @param nestStakingContract Address of the Nest Staking contract
+     * @param externalContract Address of the external contract that manages the external asset
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_,
+        IAggregateToken nestStakingContract,
+        IExternalContract externalContract
+    ) public initializer {
+        super.initialize(owner, name, symbol, currencyToken, decimals_);
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        $.nestStakingContract = nestStakingContract;
+        $.externalContract = externalContract;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestBuy(currencyTokenAmount);
+        $.externalContract.requestBuy(currencyTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestSell(componentTokenAmount);
+        $.externalContract.requestSell(componentTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeBuy(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        if (requestor != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeSell(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    // Admin Functions
+
+    function distributeYield(address user, uint256 amount) external {
+        AnemoyTokenStorage storage $ = _getAnemoyTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+
+        ComponentTokenStorage storage cs = _getComponentTokenStorage();
+        cs.currencyToken.transfer(user, amount);
+        cs.yieldAccrued[user] += amount;
+    }
+
+}

--- a/nest/src/token/CredbullToken.sol
+++ b/nest/src/token/CredbullToken.sol
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { ComponentToken } from "../ComponentToken.sol";
+
+/// @notice Example of an interface for the Nest Staking contract
+interface IAggregateToken {
+
+    /// @notice Notify the Nest Staking contract that a buy has been executed
+    function notifyBuy(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+    /// @notice Notify the Nest Staking contract that a sell has been executed
+    function notifySell(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+
+}
+
+/// @notice Example of an interface for the external contract that manages the external asset
+interface IExternalContract {
+
+    /// @notice Notify the external contract that a buy has been requested
+    function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
+    /// @notice Notify the external contract that a sell has been requested
+    function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+
+}
+
+/**
+ * @title CredbullToken
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
+ */
+contract CredbullToken is ComponentToken {
+
+    // Storage
+
+    /// @custom:storage-location erc7201:plume.storage.CredbullToken
+    struct CredbullTokenStorage {
+        /// @dev Address of the Nest Staking contract
+        IAggregateToken nestStakingContract;
+        /// @dev Address of the external contract that manages the external asset
+        IExternalContract externalContract;
+        /// @dev Mapping from request IDs to external request UUIDs
+        mapping(uint256 requestId => bytes16 externalUuid) requestMap;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.CredbullToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant CREDBULL_TOKEN_STORAGE_LOCATION =
+        0x2f245ba1b5260653d4f0c7b270773fcb1e38d72da5f2f3319d932f1818e21e00;
+
+    function _getCredbullTokenStorage() private pure returns (CredbullTokenStorage storage $) {
+        assembly {
+            $.slot := CREDBULL_TOKEN_STORAGE_LOCATION
+        }
+    }
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the caller is not the authorized caller
+     * @param invalidCaller Address of the caller that is not the authorized caller
+     * @param caller Address of the authorized caller
+     */
+    error Unauthorized(address invalidCaller, address caller);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the CredbullToken
+     * @param owner Address of the owner of the CredbullToken
+     * @param name Name of the CredbullToken
+     * @param symbol Symbol of the CredbullToken
+     * @param currencyToken CurrencyToken used to mint and burn the CredbullToken
+     * @param decimals_ Number of decimals of the CredbullToken
+     * @param nestStakingContract Address of the Nest Staking contract
+     * @param externalContract Address of the external contract that manages the external asset
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_,
+        IAggregateToken nestStakingContract,
+        IExternalContract externalContract
+    ) public initializer {
+        super.initialize(owner, name, symbol, currencyToken, decimals_);
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        $.nestStakingContract = nestStakingContract;
+        $.externalContract = externalContract;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestBuy(currencyTokenAmount);
+        $.externalContract.requestBuy(currencyTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestSell(componentTokenAmount);
+        $.externalContract.requestSell(componentTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeBuy(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        if (requestor != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeSell(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    // Admin Functions
+
+    function distributeYield(address user, uint256 amount) external {
+        CredbullTokenStorage storage $ = _getCredbullTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+
+        ComponentTokenStorage storage cs = _getComponentTokenStorage();
+        cs.currencyToken.transfer(user, amount);
+        cs.yieldAccrued[user] += amount;
+    }
+
+}

--- a/nest/src/token/CredbullToken.sol
+++ b/nest/src/token/CredbullToken.sol
@@ -41,7 +41,7 @@ interface IExternalContract {
 
 /**
  * @title CredbullToken
- * @author Eugene Y. Q. Shen
+ * @author Ian Lucas, Eugene Y. Q. Shen
  * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
  */
 contract CredbullToken is ComponentToken {

--- a/nest/src/token/DinariToken.sol
+++ b/nest/src/token/DinariToken.sol
@@ -40,7 +40,7 @@ interface IExternalContract {
 
 /**
  * @title DinariToken
- * @author Eugene Y. Q. Shen
+ * @author Jake Timothy, Eugene Y. Q. Shen
  * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
  */
 contract DinariToken is ComponentToken {

--- a/nest/src/token/DinariToken.sol
+++ b/nest/src/token/DinariToken.sol
@@ -1,0 +1,209 @@
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { ComponentToken } from "../ComponentToken.sol";
+
+/// @notice Example of an interface for the Nest Staking contract
+interface IAggregateToken {
+
+    /// @notice Notify the Nest Staking contract that a buy has been executed
+    function notifyBuy(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+    /// @notice Notify the Nest Staking contract that a sell has been executed
+    function notifySell(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+
+}
+
+/// @notice Example of an interface for the external contract that manages the external asset
+interface IExternalContract {
+
+    /// @notice Notify the external contract that a buy has been requested
+    function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
+    /// @notice Notify the external contract that a sell has been requested
+    function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+
+}
+
+/**
+ * @title DinariToken
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
+ */
+contract DinariToken is ComponentToken {
+
+    // Storage
+
+    /// @custom:storage-location erc7201:plume.storage.DinariToken
+    struct DinariTokenStorage {
+        /// @dev Address of the Nest Staking contract
+        IAggregateToken nestStakingContract;
+        /// @dev Address of the external contract that manages the external asset
+        IExternalContract externalContract;
+        /// @dev Mapping from request IDs to external request UUIDs
+        mapping(uint256 requestId => bytes16 externalUuid) requestMap;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.DinariToken")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant DINARI_TOKEN_STORAGE_LOCATION =
+        0x8a42d16a5f4a9dd4fa20afc7735f15e9454454557ef7cacfda35654781bd3100;
+
+    function _getDinariTokenStorage() private pure returns (DinariTokenStorage storage $) {
+        assembly {
+            $.slot := DINARI_TOKEN_STORAGE_LOCATION
+        }
+    }
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the caller is not the authorized caller
+     * @param invalidCaller Address of the caller that is not the authorized caller
+     * @param caller Address of the authorized caller
+     */
+    error Unauthorized(address invalidCaller, address caller);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the DinariToken
+     * @param owner Address of the owner of the DinariToken
+     * @param name Name of the DinariToken
+     * @param symbol Symbol of the DinariToken
+     * @param currencyToken CurrencyToken used to mint and burn the DinariToken
+     * @param decimals_ Number of decimals of the DinariToken
+     * @param nestStakingContract Address of the Nest Staking contract
+     * @param externalContract Address of the external contract that manages the external asset
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_,
+        IAggregateToken nestStakingContract,
+        IExternalContract externalContract
+    ) public initializer {
+        super.initialize(owner, name, symbol, currencyToken, decimals_);
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        $.nestStakingContract = nestStakingContract;
+        $.externalContract = externalContract;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestBuy(currencyTokenAmount);
+        $.externalContract.requestBuy(currencyTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestSell(componentTokenAmount);
+        $.externalContract.requestSell(componentTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeBuy(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        if (requestor != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeSell(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    // Admin Functions
+
+    function distributeYield(address user, uint256 amount) external {
+        DinariTokenStorage storage $ = _getDinariTokenStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+
+        ComponentTokenStorage storage cs = _getComponentTokenStorage();
+        cs.currencyToken.transfer(user, amount);
+        cs.yieldAccrued[user] += amount;
+    }
+
+}

--- a/nest/src/token/pUSD.sol
+++ b/nest/src/token/pUSD.sol
@@ -41,7 +41,7 @@ interface IExternalContract {
 
 /**
  * @title pUSD
- * @author Eugene Y. Q. Shen
+ * @author Chunda McCain, Jun Kim, Eugene Y. Q. Shen
  * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
  */
 contract pUSD is ComponentToken {

--- a/nest/src/token/pUSD.sol
+++ b/nest/src/token/pUSD.sol
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { ComponentToken } from "../ComponentToken.sol";
+
+/// @notice Example of an interface for the Nest Staking contract
+interface IAggregateToken {
+
+    /// @notice Notify the Nest Staking contract that a buy has been executed
+    function notifyBuy(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+    /// @notice Notify the Nest Staking contract that a sell has been executed
+    function notifySell(
+        IERC20 currencyToken,
+        IERC20 componentToken,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) external;
+
+}
+
+/// @notice Example of an interface for the external contract that manages the external asset
+interface IExternalContract {
+
+    /// @notice Notify the external contract that a buy has been requested
+    function requestBuy(uint256 currencyTokenAmount, uint256 requestId) external;
+    /// @notice Notify the external contract that a sell has been requested
+    function requestSell(uint256 componentTokenAmount, uint256 requestId) external;
+
+}
+
+/**
+ * @title pUSD
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken that interfaces with external assets.
+ */
+contract pUSD is ComponentToken {
+
+    // Storage
+
+    /// @custom:storage-location erc7201:plume.storage.pUSD
+    struct pUSDStorage {
+        /// @dev Address of the Nest Staking contract
+        IAggregateToken nestStakingContract;
+        /// @dev Address of the external contract that manages the external asset
+        IExternalContract externalContract;
+        /// @dev Mapping from request IDs to external request UUIDs
+        mapping(uint256 requestId => bytes16 externalUuid) requestMap;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("plume.storage.pUSD")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant PUSD_STORAGE_LOCATION = 0x1b5ed24c9f1f3ad78bcc8444fbe798f813c9310844a8caf12f28ce9ab492eb00;
+
+    function _getpUSDStorage() private pure returns (pUSDStorage storage $) {
+        assembly {
+            $.slot := PUSD_STORAGE_LOCATION
+        }
+    }
+
+    // Errors
+
+    /**
+     * @notice Indicates a failure because the caller is not the authorized caller
+     * @param invalidCaller Address of the caller that is not the authorized caller
+     * @param caller Address of the authorized caller
+     */
+    error Unauthorized(address invalidCaller, address caller);
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize the pUSD
+     * @param owner Address of the owner of the pUSD
+     * @param name Name of the pUSD
+     * @param symbol Symbol of the pUSD
+     * @param currencyToken CurrencyToken used to mint and burn the pUSD
+     * @param decimals_ Number of decimals of the pUSD
+     * @param nestStakingContract Address of the Nest Staking contract
+     * @param externalContract Address of the external contract that manages the external asset
+     */
+    function initialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 currencyToken,
+        uint8 decimals_,
+        IAggregateToken nestStakingContract,
+        IExternalContract externalContract
+    ) public initializer {
+        super.initialize(owner, name, symbol, currencyToken, decimals_);
+        pUSDStorage storage $ = _getpUSDStorage();
+        $.nestStakingContract = nestStakingContract;
+        $.externalContract = externalContract;
+    }
+
+    // Override Functions
+
+    /**
+     * @notice Submit a request to send currencyTokenAmount of CurrencyToken to buy ComponentToken
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @return requestId Unique identifier for the buy request
+     */
+    function requestBuy(uint256 currencyTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        pUSDStorage storage $ = _getpUSDStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestBuy(currencyTokenAmount);
+        $.externalContract.requestBuy(currencyTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Submit a request to send componentTokenAmount of ComponentToken to sell for CurrencyToken
+     * @param componentTokenAmount Amount of ComponentToken to send
+     * @return requestId Unique identifier for the sell request
+     */
+    function requestSell(uint256 componentTokenAmount) public override(ComponentToken) returns (uint256 requestId) {
+        pUSDStorage storage $ = _getpUSDStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+        requestId = super.requestSell(componentTokenAmount);
+        $.externalContract.requestSell(componentTokenAmount, requestId);
+    }
+
+    /**
+     * @notice Executes a request to buy ComponentToken with CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the buy
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to send
+     * @param componentTokenAmount Amount of ComponentToken to receive
+     */
+    function executeBuy(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        pUSDStorage storage $ = _getpUSDStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeBuy(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifyBuy(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    /**
+     * @notice Executes a request to sell ComponentToken for CurrencyToken
+     * @param requestor Address of the user or smart contract that requested the sell
+     * @param requestId Unique identifier for the request
+     * @param currencyTokenAmount Amount of CurrencyToken to receive
+     * @param componentTokenAmount Amount of ComponentToken to send
+     */
+    function executeSell(
+        address requestor,
+        uint256 requestId,
+        uint256 currencyTokenAmount,
+        uint256 componentTokenAmount
+    ) public override(ComponentToken) {
+        pUSDStorage storage $ = _getpUSDStorage();
+        if (requestor != address($.nestStakingContract)) {
+            revert Unauthorized(requestor, address($.nestStakingContract));
+        }
+        if (msg.sender != address($.externalContract)) {
+            revert Unauthorized(msg.sender, address($.externalContract));
+        }
+        super.executeSell(address($.nestStakingContract), requestId, currencyTokenAmount, componentTokenAmount);
+        $.nestStakingContract.notifySell(
+            _getComponentTokenStorage().currencyToken, this, currencyTokenAmount, componentTokenAmount
+        );
+    }
+
+    // Admin Functions
+
+    function distributeYield(address user, uint256 amount) external {
+        pUSDStorage storage $ = _getpUSDStorage();
+        if (msg.sender != address($.nestStakingContract)) {
+            revert Unauthorized(msg.sender, address($.nestStakingContract));
+        }
+
+        ComponentTokenStorage storage cs = _getComponentTokenStorage();
+        cs.currencyToken.transfer(user, amount);
+        cs.yieldAccrued[user] += amount;
+    }
+
+}


### PR DESCRIPTION
## What's new in this PR?

- Split off `IComponentToken.sol` into the buying and selling parts and separately the yield parts in `IClaimableYieldToken.sol`
- `ComponentToken.sol` is an abstract contract that we encourage all asset issuers to extend
- An example of an "adapter" implementation is in `AdapterToken.sol`, and other examples are in the `token` folder too

## Why?

What problem does this solve?
Why is this important?
What's the context?
