### PR TITLE
IERC1155Sell interface for a depositPeriod aware sell

### DIFF
--- a/nest/src/interfaces/IERC1155Sell.sol
+++ b/nest/src/interfaces/IERC1155Sell.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IComponentToken } from "./IComponentToken.sol";
+
+/**
+ * @title IERC1155Sell
+ * Example for a Deposit-Aware sell in a MultiToken vault
+ */
+interface IERC1155Sell is IComponentToken {
+
+    /**
+     * @notice Submit a request to sell shares at the given deposit periods
+     * @param shares The amount of shares to sell.
+     * @param depositPeriods The deposit periods when the shares were issued.
+     * @return requestId Unique identifier for the sell request
+     * @return assets The equivalent amount of assets for the shares
+     */
+    function requestSell(
+        uint256[] memory shares,
+        uint256[] memory depositPeriods
+    ) external view returns (uint256 requestId, uint256[] memory assets);
+
+}


### PR DESCRIPTION
## What's new in this PR?

- IERC1155Sell example interface with requestSell() that specifies the depositPeriods to sell

## Why?

- In the Credbull LiquidStone product, returns depend on the holding period.  For example, if you hold for 30 days, you receive the full 10% APY.  Holding for days 1-29 you receive the prevailing T-Bill rate.
- Our contracts extend ERC1155 to implement this behavior.  Each depositPeriod has a different ERC1155 share token specific for that day.
- This is an example interface where the seller specifies the depositPeriods they want to sell from.  If the seller doesn't want to instruct, Credbull can choose the depositPeriods to sell down on their behalf.