### PR TITLE
[CHAIN-56] only call SmartWallet with low-level calls

### DIFF
--- a/smart-wallets/src/WalletUtils.sol
+++ b/smart-wallets/src/WalletUtils.sol
@@ -9,6 +9,12 @@ pragma solidity ^0.8.25;
 contract WalletUtils {
 
     /**
+     * @notice Indicates a failure because the user's SmartWallet call failed
+     * @param user Address of the user whose SmartWallet call failed
+     */
+    error SmartWalletCallFailed(address user);
+
+    /**
      * @notice Indicates a failure because the caller is not the user wallet
      * @param invalidUser Address of the caller who tried to call a wallet-only function
      */
@@ -20,21 +26,6 @@ contract WalletUtils {
             revert UnauthorizedCall(msg.sender);
         }
         _;
-    }
-
-    /**
-     * @notice Checks if an address is a contract or smart wallet.
-     * @dev This function uses the `extcodesize` opcode to check if the target address contains contract code.
-     * It returns true for contracts and smart wallets, and false for EOAs that do not have smart wallets.
-     * @param addr Address to check
-     * @return hasCode True if the address is a contract or smart wallet, and false if it is not
-     */
-    function isContract(address addr) internal view returns (bool hasCode) {
-        uint32 size;
-        assembly {
-            size := extcodesize(addr)
-        }
-        return size > 0;
     }
 
 }

--- a/smart-wallets/src/extensions/AssetVault.sol
+++ b/smart-wallets/src/extensions/AssetVault.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { WalletUtils } from "../WalletUtils.sol";
 import { IAssetToken } from "../interfaces/IAssetToken.sol";
 import { IAssetVault } from "../interfaces/IAssetVault.sol";
 import { ISmartWallet } from "../interfaces/ISmartWallet.sol";
@@ -14,7 +15,7 @@ import { ISmartWallet } from "../interfaces/ISmartWallet.sol";
  *   in a vault, then take the yield distributed to those locked yield-bearing assets
  *   and manage the redistribution of that yield to multiple beneficiaries.
  */
-contract AssetVault is IAssetVault {
+contract AssetVault is WalletUtils, IAssetVault {
 
     // Types
 
@@ -172,16 +173,10 @@ contract AssetVault is IAssetVault {
         IAssetToken assetToken, address beneficiary, uint256 amount, uint256 amountRenounced
     );
 
-    /**
-     * @notice Indicates a failure because the caller is not the user wallet
-     * @param invalidUser Address of the caller who tried to call a wallet-only function
-     */
-    error UnauthorizedCall(address invalidUser);
-
     // Modifiers
 
     /// @notice Only the user wallet can call this function
-    modifier onlyWallet() {
+    modifier onlyUserWallet() {
         if (msg.sender != wallet) {
             revert UnauthorizedCall(msg.sender);
         }
@@ -214,7 +209,7 @@ contract AssetVault is IAssetVault {
         address beneficiary,
         uint256 amount,
         uint256 expiration
-    ) external onlyWallet {
+    ) external onlyUserWallet {
         if (address(assetToken) == address(0) || beneficiary == address(0)) {
             revert ZeroAddress();
         }
@@ -236,6 +231,8 @@ contract AssetVault is IAssetVault {
      * @notice Redistribute yield to the beneficiaries of the AssetToken, using yield distributions
      * @dev Only the user wallet can initiate the yield redistribution. The yield redistributed
      *   to each beneficiary is rounded down, and any remaining CurrencyToken are kept in the vault.
+     *   The Solidity compiler adds a check that the target address has `extcodesize > 0`
+     *   and otherwise reverts for high-level calls, so we have to use a low-level call here
      * @param assetToken AssetToken from which the yield is to be redistributed
      * @param currencyToken Token in which the yield is to be redistributed
      * @param currencyTokenAmount Amount of CurrencyToken to redistribute
@@ -244,7 +241,7 @@ contract AssetVault is IAssetVault {
         IAssetToken assetToken,
         IERC20 currencyToken,
         uint256 currencyTokenAmount
-    ) external onlyWallet {
+    ) external onlyUserWallet {
         if (currencyTokenAmount == 0) {
             return;
         }
@@ -257,7 +254,18 @@ contract AssetVault is IAssetVault {
         while (amountLocked > 0) {
             if (distribution.yield.expiration > block.timestamp) {
                 uint256 yieldShare = (currencyTokenAmount * amountLocked) / amountTotal;
-                ISmartWallet(wallet).transferYield(assetToken, distribution.beneficiary, currencyToken, yieldShare);
+                (bool success,) = wallet.call(
+                    abi.encodeWithSelector(
+                        ISmartWallet(wallet).transferYield.selector,
+                        assetToken,
+                        distribution.beneficiary,
+                        currencyToken,
+                        yieldShare
+                    )
+                );
+                if (!success) {
+                    revert SmartWalletCallFailed(wallet);
+                }
                 emit YieldRedistributed(assetToken, distribution.beneficiary, currencyToken, yieldShare);
             }
 
@@ -285,8 +293,6 @@ contract AssetVault is IAssetVault {
                 break;
             }
         }
-
-        return balanceLocked;
     }
 
     /**
@@ -313,7 +319,7 @@ contract AssetVault is IAssetVault {
         if (allowance.amount < amount) {
             revert InsufficientYieldAllowance(assetToken, beneficiary, allowance.amount, amount);
         }
-        if (assetToken.getBalanceAvailable(address(this)) < amount) {
+        if (assetToken.getBalanceAvailable(wallet) < amount) {
             revert InsufficientBalance(assetToken, amount);
         }
 

--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
+import { WalletUtils } from "../WalletUtils.sol";
 import { IAssetToken } from "../interfaces/IAssetToken.sol";
 import { ISmartWallet } from "../interfaces/ISmartWallet.sol";
-
 import { IYieldDistributionToken } from "../interfaces/IYieldDistributionToken.sol";
 import { IYieldToken } from "../interfaces/IYieldToken.sol";
 import { YieldDistributionToken } from "./YieldDistributionToken.sol";
@@ -15,7 +15,7 @@ import { YieldDistributionToken } from "./YieldDistributionToken.sol";
  * @author Eugene Y. Q. Shen
  * @notice ERC20 token that receives yield redistributions from an AssetToken
  */
-contract YieldToken is YieldDistributionToken, IYieldToken {
+contract YieldToken is YieldDistributionToken, WalletUtils, IYieldToken {
 
     // Storage
 
@@ -115,11 +115,18 @@ contract YieldToken is YieldDistributionToken, IYieldToken {
 
     /**
      * @notice Make the SmartWallet redistribute yield from their AssetToken into this YieldToken
+     * @dev The Solidity compiler adds a check that the target address has `extcodesize > 0`
+     *   and otherwise reverts for high-level calls, so we have to use a low-level call here
      * @param from Address of the SmartWallet to request the yield from
      */
     function requestYield(address from) external override(YieldDistributionToken, IYieldDistributionToken) {
         // Have to override both until updated in https://github.com/ethereum/solidity/issues/12665
-        ISmartWallet(payable(from)).claimAndRedistributeYield(_getYieldTokenStorage().assetToken);
+        (bool success,) = from.call(
+            abi.encodeWithSelector(ISmartWallet.claimAndRedistributeYield.selector, _getYieldTokenStorage().assetToken)
+        );
+        if (!success) {
+            revert SmartWalletCallFailed(from);
+        }
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

The Solidity compiler adds a check that the target address has `extcodesize > 0` and otherwise reverts for high-level calls. Since smart wallets have `extcodesize == 0` this means that all high-level `ISmartWallet` calls will revert, so we have to use low-level calls for them everywhere.

## Why?

What problem does this solve?
- TOB-PLUME-6

Why is this important?
What's the context?
