### PR TITLE
[FEA-1063] add withdraw admin methods

### DIFF
--- a/staking/src/RWAStaking.sol
+++ b/staking/src/RWAStaking.sol
@@ -234,4 +234,9 @@ contract RWAStaking is AccessControlUpgradeable, UUPSUpgradeable {
         return _getRWAStakingStorage().allowedStablecoins[stablecoin];
     }
 
+    /// @notice Timestamp of when pre-staking ends, when the admin withdraws all stablecoins
+    function getEndTime() external view returns (uint256) {
+        return _getRWAStakingStorage().endTime;
+    }
+
 }

--- a/staking/src/RWAStaking.sol
+++ b/staking/src/RWAStaking.sol
@@ -66,6 +66,14 @@ contract RWAStaking is AccessControlUpgradeable, UUPSUpgradeable {
     // Events
 
     /**
+     * @notice Emitted when an admin withdraws stablecoins from the RWAStaking contract
+     * @param user Address of the admin who withdrew stablecoins
+     * @param stablecoin Stablecoin token contract address
+     * @param amount Amount of stablecoins withdrawn
+     */
+    event Withdrawn(address indexed user, IERC20 indexed stablecoin, uint256 amount);
+
+    /**
      * @notice Emitted when a user stakes stablecoins into the RWAStaking contract
      * @param user Address of the user who staked stablecoins
      * @param stablecoin Stablecoin token contract address
@@ -133,6 +141,17 @@ contract RWAStaking is AccessControlUpgradeable, UUPSUpgradeable {
         }
         $.stablecoins.push(stablecoin);
         $.allowedStablecoins[stablecoin] = true;
+    }
+
+    /**
+     * @notice Withdraw stablecoins from the RWAStaking contract
+     * @dev Only the admin can withdraw stablecoins from the RWAStaking contract
+     * @param stablecoin Stablecoin token contract address
+     * @param amount Amount of stablecoins to withdraw
+     */
+    function withdraw(IERC20 stablecoin, uint256 amount) external onlyRole(ADMIN_ROLE) {
+        stablecoin.safeTransfer(msg.sender, amount);
+        emit Withdrawn(msg.sender, stablecoin, amount);
     }
 
     // User Functions

--- a/staking/src/SBTCStaking.sol
+++ b/staking/src/SBTCStaking.sol
@@ -194,4 +194,9 @@ contract SBTCStaking is AccessControlUpgradeable, UUPSUpgradeable {
         );
     }
 
+    /// @notice Timestamp of when pre-staking ends, when the admin withdraws all SBTC
+    function getEndTime() external view returns (uint256) {
+        return _getSBTCStakingStorage().endTime;
+    }
+
 }

--- a/staking/src/SBTCStaking.sol
+++ b/staking/src/SBTCStaking.sol
@@ -131,8 +131,7 @@ contract SBTCStaking is AccessControlUpgradeable, UUPSUpgradeable {
             revert StakingEnded();
         }
 
-        uint256 amount = $.totalAmountStaked;
-
+        uint256 amount = $.sbtc.balanceOf(address(this));
         $.sbtc.safeTransfer(msg.sender, amount);
         $.endTime = block.timestamp;
 

--- a/staking/src/SBTCStaking.sol
+++ b/staking/src/SBTCStaking.sol
@@ -64,6 +64,13 @@ contract SBTCStaking is AccessControlUpgradeable, UUPSUpgradeable {
     // Events
 
     /**
+     * @notice Emitted when an admin withdraws SBTC from the SBTCStaking contract
+     * @param user Address of the admin who withdrew stablecoins
+     * @param amount Amount of SBTC withdrawn
+     */
+    event Withdrawn(address indexed user, uint256 amount);
+
+    /**
      * @notice Emitted when a user stakes SBTC into the SBTCStaking contract
      * @param user Address of the user who staked SBTC
      * @param amount Amount of SBTC staked
@@ -104,6 +111,18 @@ contract SBTCStaking is AccessControlUpgradeable, UUPSUpgradeable {
      * @param newImplementation Address of the new implementation
      */
     function _authorizeUpgrade(address newImplementation) internal override onlyRole(UPGRADER_ROLE) { }
+
+    // Admin Functions
+
+    /**
+     * @notice Withdraw SBTC from the SBTCStaking contract
+     * @dev Only the admin can withdraw SBTC from the SBTCStaking contract
+     * @param amount Amount of SBTC to withdraw
+     */
+    function withdraw(uint256 amount) external onlyRole(ADMIN_ROLE) {
+        _getSBTCStakingStorage().sbtc.safeTransfer(msg.sender, amount);
+        emit Withdrawn(msg.sender, amount);
+    }
 
     // User Functions
 

--- a/staking/test/RWAStaking.t.sol
+++ b/staking/test/RWAStaking.t.sol
@@ -190,7 +190,7 @@ contract RWAStakingTest is Test {
         (amountSeconds, amountStaked, lastUpdate) = rwaStaking.getUserState(user1);
         assertEq(amountSeconds, stakeAmount * timeskipAmount);
         assertEq(amountStaked, stakeAmount + pusdStakeAmount);
-        assertEq(lastUpdate, startTime);
+        assertEq(lastUpdate, startTime + timeskipAmount);
 
         assertEq(usdc.balanceOf(address(rwaStaking)), 0);
         assertEq(pusd.balanceOf(address(rwaStaking)), 0);

--- a/staking/test/RWAStaking.t.sol
+++ b/staking/test/RWAStaking.t.sol
@@ -75,6 +75,7 @@ contract RWAStakingTest is Test {
         assertEq(lastUpdate, 0);
         assertEq(rwaStaking.getAllowedStablecoins().length, 0);
         assertEq(rwaStaking.isAllowedStablecoin(usdc), false);
+        assertEq(rwaStaking.getEndTime(), 0);
 
         assertTrue(rwaStaking.hasRole(rwaStaking.DEFAULT_ADMIN_ROLE(), owner));
         assertTrue(rwaStaking.hasRole(rwaStaking.ADMIN_ROLE(), owner));
@@ -196,6 +197,7 @@ contract RWAStakingTest is Test {
         assertEq(pusd.balanceOf(address(rwaStaking)), 0);
         assertEq(rwaStaking.getTotalAmountStaked(), stakeAmount + pusdStakeAmount);
         assertEq(rwaStaking.getUsers().length, 1);
+        assertEq(rwaStaking.getEndTime(), startTime + timeskipAmount);
     }
 
     function test_stakeFail() public {

--- a/staking/test/RWAStaking.t.sol
+++ b/staking/test/RWAStaking.t.sol
@@ -90,6 +90,18 @@ contract RWAStakingTest is Test {
         assertEq(pusd.balanceOf(user2), INITIAL_BALANCE);
     }
 
+    function test_stakingEnded() public {
+        vm.startPrank(owner);
+        rwaStaking.withdraw();
+
+        vm.expectRevert(abi.encodeWithSelector(RWAStaking.StakingEnded.selector));
+        rwaStaking.stake(100 ether, usdc);
+        vm.expectRevert(abi.encodeWithSelector(RWAStaking.StakingEnded.selector));
+        rwaStaking.withdraw();
+
+        vm.stopPrank();
+    }
+
     function test_allowStablecoinFail() public {
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -121,6 +133,69 @@ contract RWAStakingTest is Test {
         assertEq(rwaStaking.isAllowedStablecoin(pusd), true);
 
         vm.stopPrank();
+    }
+
+    function test_withdrawFail() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user1, rwaStaking.ADMIN_ROLE()
+            )
+        );
+        vm.startPrank(user1);
+        rwaStaking.withdraw();
+        vm.stopPrank();
+    }
+
+    function test_withdraw() public {
+        uint256 stakeAmount = 100 ether;
+        uint256 pusdStakeAmount = 30 ether;
+        uint256 timeskipAmount = 300;
+        uint256 startTime = block.timestamp;
+        helper_initialStake(user1, stakeAmount);
+
+        (uint256 amountSeconds, uint256 amountStaked, uint256 lastUpdate) = rwaStaking.getUserState(user1);
+        assertEq(amountSeconds, 0);
+        assertEq(amountStaked, stakeAmount);
+        assertEq(lastUpdate, startTime);
+
+        // Skip ahead in time by 300 seconds and check that amountSeconds has changed
+        vm.warp(startTime + timeskipAmount);
+        (amountSeconds, amountStaked, lastUpdate) = rwaStaking.getUserState(user1);
+        assertEq(amountSeconds, stakeAmount * timeskipAmount);
+        assertEq(amountStaked, stakeAmount);
+        assertEq(lastUpdate, startTime);
+
+        vm.startPrank(owner);
+        rwaStaking.allowStablecoin(pusd);
+        vm.stopPrank();
+
+        vm.startPrank(user1);
+        pusd.approve(address(rwaStaking), pusdStakeAmount);
+        rwaStaking.stake(pusdStakeAmount, pusd);
+        vm.stopPrank();
+
+        assertEq(usdc.balanceOf(address(rwaStaking)), stakeAmount);
+        assertEq(pusd.balanceOf(address(rwaStaking)), pusdStakeAmount);
+
+        vm.startPrank(owner);
+        vm.expectEmit(true, true, false, true, address(rwaStaking));
+        emit RWAStaking.Withdrawn(owner, usdc, stakeAmount);
+        vm.expectEmit(true, true, false, true, address(rwaStaking));
+        emit RWAStaking.Withdrawn(owner, pusd, pusdStakeAmount);
+        rwaStaking.withdraw();
+        vm.stopPrank();
+
+        // Skip ahead in time by 300 seconds and check that amountSeconds is fixed
+        vm.warp(startTime + timeskipAmount * 2);
+        (amountSeconds, amountStaked, lastUpdate) = rwaStaking.getUserState(user1);
+        assertEq(amountSeconds, stakeAmount * timeskipAmount);
+        assertEq(amountStaked, stakeAmount + pusdStakeAmount);
+        assertEq(lastUpdate, startTime);
+
+        assertEq(usdc.balanceOf(address(rwaStaking)), 0);
+        assertEq(pusd.balanceOf(address(rwaStaking)), 0);
+        assertEq(rwaStaking.getTotalAmountStaked(), stakeAmount + pusdStakeAmount);
+        assertEq(rwaStaking.getUsers().length, 1);
     }
 
     function test_stakeFail() public {

--- a/staking/test/SBTCStaking.t.sol
+++ b/staking/test/SBTCStaking.t.sol
@@ -59,6 +59,8 @@ contract SBTCStakingTest is Test {
         assertEq(address(sbtcStaking.getSBTC()), address(sbtc));
         assertEq(sbtcStaking.getTotalAmountStaked(), 0);
         assertEq(sbtcStaking.getUsers().length, 0);
+        assertEq(sbtcStaking.getEndTime(), 0);
+
         (uint256 amountSeconds, uint256 amountStaked, uint256 lastUpdate) = sbtcStaking.getUserState(user1);
         assertEq(amountSeconds, 0);
         assertEq(amountStaked, 0);
@@ -132,6 +134,7 @@ contract SBTCStakingTest is Test {
         assertEq(sbtc.balanceOf(address(sbtcStaking)), 0);
         assertEq(sbtcStaking.getTotalAmountStaked(), stakeAmount);
         assertEq(sbtcStaking.getUsers().length, 1);
+        assertEq(sbtcStaking.getEndTime(), startTime + timeskipAmount);
     }
 
     function test_stakeFail() public {

--- a/staking/test/SBTCStaking.t.sol
+++ b/staking/test/SBTCStaking.t.sol
@@ -74,6 +74,66 @@ contract SBTCStakingTest is Test {
         assertEq(sbtc.balanceOf(user2), INITIAL_BALANCE);
     }
 
+    function test_stakingEnded() public {
+        vm.startPrank(owner);
+        sbtcStaking.withdraw();
+
+        vm.expectRevert(abi.encodeWithSelector(SBTCStaking.StakingEnded.selector));
+        sbtcStaking.stake(100 ether);
+        vm.expectRevert(abi.encodeWithSelector(SBTCStaking.StakingEnded.selector));
+        sbtcStaking.withdraw();
+
+        vm.stopPrank();
+    }
+
+    function test_withdrawFail() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector, user1, sbtcStaking.ADMIN_ROLE()
+            )
+        );
+        vm.startPrank(user1);
+        sbtcStaking.withdraw();
+        vm.stopPrank();
+    }
+
+    function test_withdraw() public {
+        uint256 stakeAmount = 100 ether;
+        uint256 timeskipAmount = 300;
+        uint256 startTime = block.timestamp;
+        helper_initialStake(user1, stakeAmount);
+
+        (uint256 amountSeconds, uint256 amountStaked, uint256 lastUpdate) = sbtcStaking.getUserState(user1);
+        assertEq(amountSeconds, 0);
+        assertEq(amountStaked, stakeAmount);
+        assertEq(lastUpdate, startTime);
+
+        // Skip ahead in time by 300 seconds and check that amountSeconds has changed
+        vm.warp(startTime + timeskipAmount);
+        (amountSeconds, amountStaked, lastUpdate) = sbtcStaking.getUserState(user1);
+        assertEq(amountSeconds, stakeAmount * timeskipAmount);
+        assertEq(amountStaked, stakeAmount);
+        assertEq(lastUpdate, startTime);
+        assertEq(sbtc.balanceOf(address(sbtcStaking)), stakeAmount);
+
+        vm.startPrank(owner);
+        vm.expectEmit(true, false, false, true, address(sbtcStaking));
+        emit SBTCStaking.Withdrawn(owner, stakeAmount);
+        sbtcStaking.withdraw();
+        vm.stopPrank();
+
+        // Skip ahead in time by 300 seconds and check that amountSeconds is fixed
+        vm.warp(startTime + timeskipAmount * 2);
+        (amountSeconds, amountStaked, lastUpdate) = sbtcStaking.getUserState(user1);
+        assertEq(amountSeconds, stakeAmount * timeskipAmount);
+        assertEq(amountStaked, stakeAmount);
+        assertEq(lastUpdate, startTime);
+
+        assertEq(sbtc.balanceOf(address(sbtcStaking)), 0);
+        assertEq(sbtcStaking.getTotalAmountStaked(), stakeAmount);
+        assertEq(sbtcStaking.getUsers().length, 1);
+    }
+
     function test_stakeFail() public {
         uint256 stakeAmount = 100 ether;
         vm.startPrank(user3);


### PR DESCRIPTION
## What's new in this PR?

Add admin methods that allow only the admin to withdraw funds from the pre-staking contract in order to transfer them to the official staking contract.

## Why?

What problem does this solve?
Why is this important?
What's the context?
