### PR TITLE
[NES-239] create fake USDT contract on testnet

### DIFF
--- a/nest/script/DeployUSDT.sol
+++ b/nest/script/DeployUSDT.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { USDTProxy } from "../src/proxy/USDTProxy.sol";
+import { USDT } from "../src/token/USDT.sol";
+import { USDTAsset } from "../src/token/USDTAsset.sol";
+
+contract DeployNestContracts is Script {
+
+    address private constant NEST_ADMIN_ADDRESS = 0xb015762405De8fD24d29A6e0799c12e0Ea81c1Ff;
+
+    function run() external {
+        vm.startBroadcast(NEST_ADMIN_ADDRESS);
+
+        USDTAsset usdtAsset = new USDTAsset(NEST_ADMIN_ADDRESS);
+        console2.log("USDT Asset deployed to:", address(usdtAsset));
+
+        USDT usdt = new USDT();
+        USDTProxy usdtProxy =
+            new USDTProxy(address(usdt), abi.encodeCall(USDT.initialize, (NEST_ADMIN_ADDRESS, usdtAsset)));
+        console2.log("USDT Component Token Proxy deployed to:", address(usdtProxy));
+
+        vm.stopBroadcast();
+    }
+
+}

--- a/nest/src/proxy/USDTProxy.sol
+++ b/nest/src/proxy/USDTProxy.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/**
+ * @title USDTProxy
+ * @author Eugene Y. Q. Shen
+ * @notice Proxy contract for USDT
+ */
+contract USDTProxy is ERC1967Proxy {
+
+    /// @notice Name of the proxy, used to ensure each named proxy has unique bytecode
+    bytes32 public constant PROXY_NAME = keccak256("USDTProxy");
+
+    constructor(address logic, bytes memory data) ERC1967Proxy(logic, data) { }
+
+    /// @dev Fallback function to silence compiler warnings
+    receive() external payable { }
+
+}

--- a/nest/src/token/USDT.sol
+++ b/nest/src/token/USDT.sol
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { ComponentToken } from "../ComponentToken.sol";
+import { IComponentToken } from "../interfaces/IComponentToken.sol";
+
+/**
+ * @title USDT
+ * @author Eugene Y. Q. Shen
+ * @notice Implementation of the abstract ComponentToken for an infinite supply stablecoin.
+ */
+contract USDT is ComponentToken {
+
+    // Initializer
+
+    /**
+     * @notice Prevent the implementation contract from being initialized or reinitialized
+     * @custom:oz-upgrades-unsafe-allow constructor
+     */
+    constructor() {
+        _disableInitializers();
+    }
+
+    /**
+     * @notice Initialize USDT
+     * @param owner Address of the owner of USDT
+     */
+    function initialize(address owner, IERC20 asset_) public initializer {
+        super.initialize(owner, "Tether USD", "USDT", asset_, false, false);
+    }
+
+    // Override Functions
+
+    /**
+     * @inheritdoc IERC4626
+     * @dev 1:1 conversion rate between USDT and base asset
+     */
+    function convertToShares(uint256 assets) public pure override(ComponentToken) returns (uint256 shares) {
+        return assets;
+    }
+
+    /**
+     * @inheritdoc IERC4626
+     * @dev 1:1 conversion rate between USDT and base asset
+     */
+    function convertToAssets(uint256 shares) public pure override(ComponentToken) returns (uint256 assets) {
+        return shares;
+    }
+
+    /**
+     * @inheritdoc IComponentToken
+     * @dev 1:1 conversion rate between USDT and base asset
+     * @dev To enable load testing with constant calldata, does not require msg.sender to equal controller
+     */
+    function deposit(
+        uint256 assets,
+        address receiver,
+        address controller
+    ) public override(ComponentToken) returns (uint256 shares) {
+        if (assets == 0) {
+            revert ZeroAmount();
+        }
+
+        if (!IERC20(asset()).transferFrom(controller, address(this), assets)) {
+            revert InsufficientBalance(IERC20(asset()), controller, assets);
+        }
+        shares = convertToShares(assets);
+
+        _mint(receiver, shares);
+
+        emit Deposit(controller, receiver, assets, shares);
+    }
+
+}

--- a/nest/src/token/USDTAsset.sol
+++ b/nest/src/token/USDTAsset.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+/**
+ * @title USDTAsset
+ * @author Eugene Y. Q. Shen
+ * @notice Base asset for USDT ComponentToken
+ */
+contract USDTAsset is ERC20, Ownable {
+
+    constructor(address owner_) ERC20("USDTAsset", "USDT_") Ownable(owner_) { }
+
+    function mint(address to, uint256 amount) public onlyOwner {
+        _mint(to, amount);
+    }
+
+    function decimals() public pure override returns (uint8) {
+        return 6;
+    }
+
+}


### PR DESCRIPTION
## What's new in this PR?

Create fake `USDT` contract on testnet that extends `ComponentToken` and can be put into a Nucleus `pUSD` vault to simulate `IComponentToken`-compatible synchronous deposit/redeems.
## Why?

What problem does this solve?
Why is this important?
What's the context?
