### PR TITLE
fix tests that break when compiled with --ir-minimum

### DIFF
--- a/staking/test/RWAStaking.t.sol
+++ b/staking/test/RWAStaking.t.sol
@@ -169,7 +169,8 @@ contract RWAStakingTest is Test {
         uint256 stakeAmount = 100 ether;
         uint256 pusdStakeAmount = 30 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
         helper_initialStake(user1, stakeAmount);
 
         (uint256 amountSeconds, uint256 amountStaked, uint256 lastUpdate) = rwaStaking.getUserState(user1);
@@ -312,7 +313,8 @@ contract RWAStakingTest is Test {
     function test_withdraw() public {
         uint256 stakeAmount = 100 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
 
         // Stake from user1
         helper_initialStake(user1, stakeAmount);
@@ -392,7 +394,8 @@ contract RWAStakingTest is Test {
     function test_stake() public {
         uint256 stakeAmount = 100 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
 
         // Stake 100 USDC from user1
         helper_initialStake(user1, stakeAmount);

--- a/staking/test/ReserveStaking.t.sol
+++ b/staking/test/ReserveStaking.t.sol
@@ -164,7 +164,8 @@ contract ReserveStakingTest is Test {
         uint256 sbtcAmount = 100 ether;
         uint256 stoneAmount = 50 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
         helper_initialStake(user1, sbtcAmount, stoneAmount);
 
         (
@@ -324,7 +325,8 @@ contract ReserveStakingTest is Test {
         uint256 sbtcAmount = 100 ether;
         uint256 stoneAmount = 50 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
 
         // Stake from user1
         helper_initialStake(user1, sbtcAmount, stoneAmount);
@@ -425,7 +427,8 @@ contract ReserveStakingTest is Test {
         uint256 sbtcAmount = 100 ether;
         uint256 stoneAmount = 50 ether;
         uint256 timeskipAmount = 300;
-        uint256 startTime = block.timestamp;
+        uint256 startTime = 1;
+        vm.warp(startTime);
 
         // Stake from user1
         helper_initialStake(user1, sbtcAmount, stoneAmount);


### PR DESCRIPTION
## What's new in this PR?

When compiling with intermediate representation, the `uint256 startTime = block.timestamp` is optimized out and replaced with `block.timestamp` throughout, which makes tests fail when warping around. Resolves #73.

## Why?

What problem does this solve?
Why is this important?
What's the context?
