### PR TITLE
feat: make vault notification methods internal

### DIFF
--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -254,7 +254,7 @@ abstract contract ComponentToken is
      * @param shares Amount of shares to receive in exchange
      * @param controller Controller of the request
      */
-    function notifyDeposit(uint256 assets, uint256 shares, address controller) public virtual {
+    function _notifyDeposit(uint256 assets, uint256 shares, address controller) internal virtual {
         if (assets == 0) {
             revert ZeroAmount();
         }
@@ -363,7 +363,7 @@ abstract contract ComponentToken is
      * @param shares Amount of shares that was redeemed by `requestRedeem`
      * @param controller Controller of the request
      */
-    function notifyRedeem(uint256 assets, uint256 shares, address controller) public virtual {
+    function _notifyRedeem(uint256 assets, uint256 shares, address controller) internal virtual {
         if (shares == 0) {
             revert ZeroAmount();
         }


### PR DESCRIPTION
## What's new in this PR?

Make ComponentToken methods notifyDeposit and notifyRedeem internal.

## Why?

ComponentToken methods notifyDeposit and notifyRedeem add public methods to the ABI. Issuers  - such as Dinari - may implement other methods when extending ComponentToken which handle the transition of orders from pending to claimable. 

Rather than have dead code in ComponentToken, this PR makes the current methods internal so they can be used to provide consistent notification events and arithmetic without adding opinionated methods to the ABI.

Example: https://github.com/dinaricrypto/sbt-contracts/pull/374
