### PR TITLE
[FEA-1064] deploy pre-staking contracts to mainnet

### DIFF
--- a/smart-wallets/test/TestWalletImplementation.t.sol
+++ b/smart-wallets/test/TestWalletImplementation.t.sol
@@ -18,7 +18,7 @@ contract TestWalletImplementationTest is Test {
     /* forge coverage --ir-minimum */
     address constant EMPTY_ADDRESS = 0x0Ab1C3d2cCB7c314666185b317900a614e516feB;
     address constant WALLET_FACTORY_ADDRESS = 0x20bb256ADCDF463Cff377152FEa514d14A4464b7;
-    address constant WALLET_PROXY_ADDRESS = 0x4920a4ba4752Ac88dF5f7BEaE071178B2b94e7d3;
+    address constant WALLET_PROXY_ADDRESS = 0x9CD5E3Ec9826647BBDBa85bBced53FB7aC8c13a0;
 
     /* forge test
     address constant EMPTY_ADDRESS = 0x14E90063Fb9d5F9a2b0AB941679F105C1A597C7C;

--- a/staking/script/DeployTestStakingContracts.s.sol
+++ b/staking/script/DeployTestStakingContracts.s.sol
@@ -12,30 +12,29 @@ import { STONE } from "../src/STONE.sol";
 import { PlumePreReserveFund } from "../src/proxy/PlumePreReserveFund.sol";
 import { PlumePreStaking } from "../src/proxy/PlumePreStaking.sol";
 
-contract DeployStakingContracts is Script {
+contract DeployTestStakingContracts is Script {
 
-    address private constant ADMIN_ADDRESS = 0xDE1509CC56D740997c70E1661BA687e950B4a241;
-    address private constant USDC_ADDRESS = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address private constant USDT_ADDRESS = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
-    address private constant SBTC_ADDRESS = 0x094c0e36210634c3CfA25DC11B96b562E0b07624;
-    address private constant STONE_ADDRESS = 0x7122985656e38BDC0302Db86685bb972b145bD3C;
+    address private constant NEST_ADMIN_ADDRESS = 0xb015762405De8fD24d29A6e0799c12e0Ea81c1Ff;
+    address private constant PUSD_ADDRESS = 0xe644F07B1316f28a7F134998e021eA9f7135F351;
+    address private constant USDT_ADDRESS = 0x2413b8C79Ce60045882559f63d308aE3DFE0903d;
 
     function test() public { }
 
     function run() external {
-        vm.startBroadcast(ADMIN_ADDRESS);
+        vm.startBroadcast(NEST_ADMIN_ADDRESS);
 
         RWAStaking rwaStaking = new RWAStaking();
         PlumePreStaking plumePreStaking =
-            new PlumePreStaking(address(rwaStaking), abi.encodeCall(RWAStaking.initialize, (ADMIN_ADDRESS)));
-        RWAStaking(address(plumePreStaking)).allowStablecoin(IERC20(USDC_ADDRESS));
+            new PlumePreStaking(address(rwaStaking), abi.encodeCall(RWAStaking.initialize, (NEST_ADMIN_ADDRESS)));
+        RWAStaking(address(plumePreStaking)).allowStablecoin(IERC20(PUSD_ADDRESS));
         RWAStaking(address(plumePreStaking)).allowStablecoin(IERC20(USDT_ADDRESS));
         console2.log("Plume Pre-Staking Proxy deployed to:", address(plumePreStaking));
 
+        SBTC sbtc = new SBTC(NEST_ADMIN_ADDRESS);
+        STONE stone = new STONE(NEST_ADMIN_ADDRESS);
         ReserveStaking sbtcStaking = new ReserveStaking();
         PlumePreReserveFund plumePreReserveFund = new PlumePreReserveFund(
-            address(sbtcStaking),
-            abi.encodeCall(ReserveStaking.initialize, (ADMIN_ADDRESS, IERC20(SBTC_ADDRESS), IERC20(STONE_ADDRESS)))
+            address(sbtcStaking), abi.encodeCall(ReserveStaking.initialize, (NEST_ADMIN_ADDRESS, sbtc, stone))
         );
         console2.log("Plume Pre-Reserve Fund Proxy deployed to:", address(plumePreReserveFund));
 


### PR DESCRIPTION
## What's new in this PR?

Contracts deployed to:
- RWA Pre-Staking: [0xdbd03D676e1cf3c3b656972F88eD21784372AcAB](https://etherscan.io/address/0xdbd03D676e1cf3c3b656972F88eD21784372AcAB)
- Reserve Fund Pre-Staking: [0xBa0Ae7069f94643853Fce3B8Af7f55AcBC11e397](https://etherscan.io/address/0xBa0Ae7069f94643853Fce3B8Af7f55AcBC11e397)

## Why?

What problem does this solve?
Why is this important?
What's the context?
