### PR TITLE
[FIX] - YieldDistributionToken.accrueYield

### DIFF
--- a/smart-wallets/src/token/YieldDistributionToken.sol
+++ b/smart-wallets/src/token/YieldDistributionToken.sol
@@ -368,6 +368,9 @@ abstract contract YieldDistributionToken is ERC20, Ownable, IYieldDistributionTo
                     break;
                 }
 
+                // if user has a lot of deposits to accrueYield for, 
+                // we break out of the loop here instead of reverting 
+                // when gas gets too low.
                 if (gasleft() < 100_000) {
                     break;
                 }
@@ -381,7 +384,10 @@ abstract contract YieldDistributionToken is ERC20, Ownable, IYieldDistributionTo
             emit YieldAccrued(user, userState.yieldAccrued);
         }
 
-        _updateUserAmountSeconds(user);
+        // only update this if we didn't break out of the loop early b/c of gas limit.
+        if (lastDepositIndex == currentDepositIndex) {
+            _updateUserAmountSeconds(user);
+        }
     }
 
 }


### PR DESCRIPTION
only call _updateUserAmountSeconds in accrueYield if no early break b/c of gas limit otherwise there'll be an underflow during the next call to accrueYield for the user b/c the userState.lastUpdate is still updated to the block.timestamp in `_updateUserAmountSeconds` and the next time `accrueYield` is called again for the user, the `deposit.timestamp` will be < `userState.lastUpdate` in the `accrueYield` loop

alternative fix would be to change the _updateUserAmountSeconds to something like this
```
    function _updateUserAmountSeconds(
        address account
    ) internal {
        YieldDistributionTokenStorage storage $ = _getYieldDistributionTokenStorage();
        UserState storage userState = $.userStates[account];
        uint256 currentDepositIndex = $.deposits.length - 1;
        uint256 lastDepositIndex = userState.lastDepositIndex;
        uint256 ts = currentDepositIndex == lastDepositIndex ? block.timestamp : userState.lastUpdate;
        userState.amountSeconds += balanceOf(account) * (ts - userState.lastUpdate);
        userState.lastUpdate = ts;
    }
```
## What's new in this PR?

In bullet point format, please describe what's new in this PR.

## Why?

What problem does this solve?
Why is this important?
What's the context?
