### PR TITLE
[NES-294] [Fix] Slowmist remediations update

### DIFF
--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -174,7 +174,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
         uint256 assets,
         address receiver,
         address controller
-    ) public override(ComponentToken, IComponentToken, ERC4626Upgradeable) returns (uint256 shares) {
+    ) public override(ComponentToken, IComponentToken) returns (uint256 shares) {
         if (_getAggregateTokenStorage().paused) {
             revert DepositPaused();
         }

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -581,7 +581,7 @@ abstract contract ComponentToken is
             $.claimableRedeemRequest[controller] = 0;
             $.assetsRedeemRequest[controller] = 0;
 
-        // No _burn needed here as shares were already burned in requestRedeem
+            // No _burn needed here as shares were already burned in requestRedeem
             SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
         } else {
             shares = previewWithdraw(assets);

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -386,13 +386,22 @@ abstract contract ComponentToken is
             if ($.sharesDepositRequest[controller] < shares) {
                 revert InsufficientRequestBalance(controller, shares, 1);
             }
-            // Use the pre-calculated assets amount from when deposit was notified
+
+            // Get the pre-calculated values
+            uint256 claimableShares = $.sharesDepositRequest[controller];
             assets = $.claimableDepositRequest[controller];
+
+            // Verify shares match exactly
+            if (shares != claimableShares) {
+                revert InvalidDepositAmount(shares, claimableShares);
+            }
+
+            // Reset state atomically
             $.claimableDepositRequest[controller] = 0;
             $.sharesDepositRequest[controller] = 0;
         } else {
             assets = previewMint(shares);
-            _deposit(msg.sender, receiver, assets, shares);
+            SafeERC20.safeTransferFrom(IERC20(asset()), controller, address(this), assets);
         }
         _mint(receiver, shares);
         emit Deposit(msg.sender, receiver, assets, shares);
@@ -547,7 +556,7 @@ abstract contract ComponentToken is
         address receiver,
         address controller
     ) public virtual override(ERC4626Upgradeable, IERC7540) nonReentrant returns (uint256 shares) {
-        if (shares == 0) {
+        if (assets == 0) {
             revert ZeroAmount();
         }
         if (msg.sender != controller) {
@@ -556,18 +565,29 @@ abstract contract ComponentToken is
 
         ComponentTokenStorage storage $ = _getComponentTokenStorage();
         if ($.asyncRedeem) {
-            // Use the pre-calculated assets amount from when redeem was notified
             if ($.assetsRedeemRequest[controller] < assets) {
                 revert InsufficientRequestBalance(controller, assets, 3);
             }
+            // Get the pre-calculated values
+            uint256 claimableAssets = $.assetsRedeemRequest[controller];
             shares = $.claimableRedeemRequest[controller];
+
+            // Verify assets match exactly
+            if (assets != claimableAssets) {
+                revert InvalidRedeemAmount(assets, claimableAssets);
+            }
+
+            // Reset state atomically
             $.claimableRedeemRequest[controller] = 0;
             $.assetsRedeemRequest[controller] = 0;
+
+        // No _burn needed here as shares were already burned in requestRedeem
+            SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
         } else {
             shares = previewWithdraw(assets);
-            _withdraw(msg.sender, receiver, msg.sender, assets, shares);
+            _burn(msg.sender, shares);
+            SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
         }
-        _burn(msg.sender, shares);
         emit Withdraw(msg.sender, receiver, msg.sender, assets, shares);
         return shares;
     }

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -583,12 +583,11 @@ abstract contract ComponentToken is
 
             // No _burn needed here as shares were already burned in requestRedeem
             SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
+            emit Withdraw(controller, receiver, controller, assets, shares);
         } else {
             shares = previewWithdraw(assets);
-            _burn(msg.sender, shares);
-            SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);
+            _withdraw(controller, receiver, controller, assets, shares);
         }
-        emit Withdraw(msg.sender, receiver, msg.sender, assets, shares);
         return shares;
     }
 

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -389,14 +389,13 @@ abstract contract ComponentToken is
 
             // Get the pre-calculated values
             uint256 claimableShares = $.sharesDepositRequest[controller];
-            assets = $.claimableDepositRequest[controller];
 
             // Verify shares match exactly
             if (shares != claimableShares) {
                 revert InvalidDepositAmount(shares, claimableShares);
             }
 
-            // Reset state atomically
+            assets = $.claimableDepositRequest[controller];
             $.claimableDepositRequest[controller] = 0;
             $.sharesDepositRequest[controller] = 0;
         } else {


### PR DESCRIPTION
## What's new in this PR?

1. In PR120, the mint function of ComponentToken contract uses ERC4626's _deposit function for token deposits. However, it's important to note that the _deposit function in ERC4626 already mints shares to users, while the mint function in ComponentToken also uses _mint to mint shares again. This results in users receiving double shares.
```
function mint(
    uint256 shares,
    address receiver,
    address controller
) public virtual nonReentrant returns (uint256 assets) {
    ...
    } else {
        assets = previewMint(shares);
        _deposit(msg.sender, receiver, assets, shares);
    }
    _mint(receiver, shares);
    ...
}
```
2. In PR120, during asynchronous minting, the mint function of ComponentToken contract doesn't verify if the user-provided shares amount matches the recorded amount in sharesDepositRequest. This could result in users receiving fewer shares than their deducted async deposit balance.
```
function mint(
    uint256 shares,
    address receiver,
    address controller
) public virtual nonReentrant returns (uint256 assets) {
    ...
    if ($.asyncDeposit) {
        if ($.sharesDepositRequest[controller] < shares) {
            revert InsufficientRequestBalance(controller, shares, 1);
        }
        // Use the pre-calculated assets amount from when deposit was notified
        assets = $.claimableDepositRequest[controller];
        $.claimableDepositRequest[controller] = 0;
        $.sharesDepositRequest[controller] = 0;
    } else {
        ...
    }
    _mint(receiver, shares);
    ...
}
```
3. In PR120, the withdraw function of ComponentToken contract incorrectly checks shares at the beginning, when it should be checking the user-provided assets amount.
```
function withdraw(
    uint256 assets,
    address receiver,
    address controller
) public virtual override(ERC4626Upgradeable, IERC7540) nonReentrant returns (uint256 shares) {
    if (shares == 0) {
        revert ZeroAmount();
    }
    ...
}
```
4. In PR120, during asynchronous withdrawal, the withdraw function doesn't verify if the user-provided assets amount matches the recorded amount in assetsRedeemRequest. This could result in the contract transferring fewer assets to users than the recorded assetsRedeemRequest amount.
```
function withdraw(
    uint256 assets,
    address receiver,
    address controller
) public virtual override(ERC4626Upgradeable, IERC7540) nonReentrant returns (uint256 shares) {
    ...
    if ($.asyncRedeem) {
        // Use the pre-calculated assets amount from when redeem was notified
        if ($.assetsRedeemRequest[controller] < assets) {
            revert InsufficientRequestBalance(controller, assets, 3);
        }
        shares = $.claimableRedeemRequest[controller];
        $.claimableRedeemRequest[controller] = 0;
        $.assetsRedeemRequest[controller] = 0;
    } ...
}
```
5. In PR120, after asynchronous withdrawal, the withdraw function of ComponentToken contract fails to implement the functionality to transfer assets tokens to the receiver, preventing users from recovering funds through async withdrawal.

6. In PR120, the withdraw function of ComponentToken contract performs a _burn operation after user withdrawal. However, for async withdrawals, the requestRedeem function has already burned the user's shares, and for sync withdrawals, the _withdraw function has also burned the user's shares. This leads to double-burning of user shares.
```
   function withdraw(
        uint256 assets,
        address receiver,
        address controller
    ) public virtual override(ERC4626Upgradeable, IERC7540) nonReentrant returns (uint256 shares) {
        ...
        _burn(msg.sender, shares);
        emit Withdraw(msg.sender, receiver, msg.sender, assets, shares);
        return shares;
    }
```

7. In PR112, the function deposit(uint256 assets, address receiver, address controller) doesn't need to override the ERC4626Upgradeable contract, as this function doesn't exist in ERC4626Upgradeable.

```
    function deposit(
        ...
    ) public override(ComponentToken, IComponentToken, ERC4626Upgradeable) returns (uint256 shares) {
        ...
    }
```