### PR TITLE
[NES-296] [Fix] Remove double nonreentrant modifiers.

### DIFF
--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -169,6 +169,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
     }
 
     /// @inheritdoc IComponentToken
+    /// @dev Do not add reentrancy guard here, as it is already handled in the parent contract
     function deposit(
         uint256 assets,
         address receiver,
@@ -182,7 +183,8 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
 
     /**
      * @inheritdoc ERC4626Upgradeable
-     * @dev Overridden to add pause check before deposit
+     * @dev Overridden to add pause check before deposit. Do not add reentrancy guard here, as it is already handled in
+     * the parent contract
      * @param assets Amount of assets to deposit
      * @param receiver Address that will receive the shares
      * @return shares Amount of shares minted
@@ -199,7 +201,8 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
 
     /**
      * @inheritdoc ComponentToken
-     * @dev Overridden to add pause check before minting
+     * @dev Overridden to add pause check before minting. Do not add reentrancy guard here, as it is already handled in
+     * the parent contract
      * @param shares Amount of shares to mint
      * @param receiver Address that will receive the shares
      * @param controller Address that controls the minting
@@ -218,7 +221,8 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
 
     /**
      * @inheritdoc ERC4626Upgradeable
-     * @dev Overridden to add pause check before minting
+     * @dev Overridden to add pause check before minting. Do not add reentrancy guard here, as it is already handled in
+     * the parent contract
      * @param shares Amount of shares to mint
      * @param receiver Address that will receive the shares
      * @return assets Amount of assets deposited
@@ -234,6 +238,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
     }
 
     /// @inheritdoc IComponentToken
+    /// @dev Do not add reentrancy guard here, as it is already handled in the parent contract
     function redeem(
         uint256 shares,
         address receiver,

--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -173,7 +173,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
         uint256 assets,
         address receiver,
         address controller
-    ) public override(ComponentToken, IComponentToken) nonReentrant returns (uint256 shares) {
+    ) public override(ComponentToken, IComponentToken) returns (uint256 shares) {
         if (_getAggregateTokenStorage().paused) {
             revert DepositPaused();
         }
@@ -190,7 +190,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
     function deposit(
         uint256 assets,
         address receiver
-    ) public override(ERC4626Upgradeable, IERC4626) nonReentrant returns (uint256 shares) {
+    ) public override(ERC4626Upgradeable, IERC4626) returns (uint256 shares) {
         if (_getAggregateTokenStorage().paused) {
             revert DepositPaused();
         }
@@ -209,7 +209,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
         uint256 shares,
         address receiver,
         address controller
-    ) public override(ComponentToken) nonReentrant returns (uint256 assets) {
+    ) public override(ComponentToken) returns (uint256 assets) {
         if (_getAggregateTokenStorage().paused) {
             revert DepositPaused();
         }
@@ -226,7 +226,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
     function mint(
         uint256 shares,
         address receiver
-    ) public override(ERC4626Upgradeable, IERC4626) nonReentrant returns (uint256 assets) {
+    ) public override(ERC4626Upgradeable, IERC4626) returns (uint256 assets) {
         if (_getAggregateTokenStorage().paused) {
             revert DepositPaused();
         }
@@ -238,7 +238,7 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
         uint256 shares,
         address receiver,
         address controller
-    ) public override(ComponentToken, IComponentToken) nonReentrant returns (uint256 assets) {
+    ) public override(ComponentToken, IComponentToken) returns (uint256 assets) {
         return super.redeem(shares, receiver, controller);
     }
 


### PR DESCRIPTION
## What's new in this PR?

getting double reentrancy on tests, fixed.