### PR TITLE
[PDE-234] add onlyInitializing reinitializer to ComponentToken

### DIFF
--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -213,6 +213,35 @@ abstract contract ComponentToken is
         $.asyncRedeem = asyncRedeem;
     }
 
+    /**
+     * @notice Reinitialize the ComponentToken
+     * @param owner Address of the owner of the ComponentToken
+     * @param name Name of the ComponentToken
+     * @param symbol Symbol of the ComponentToken
+     * @param asset_ Asset used to mint and burn the ComponentToken
+     * @param asyncDeposit True if deposits are asynchronous; false otherwise
+     * @param asyncRedeem True if redemptions are asynchronous; false otherwise
+     */
+    function reinitialize(
+        address owner,
+        string memory name,
+        string memory symbol,
+        IERC20 asset_,
+        bool asyncDeposit,
+        bool asyncRedeem
+    ) public onlyInitializing {
+        __ERC20_init(name, symbol);
+        __ERC4626_init(asset_);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, owner);
+        _grantRole(ADMIN_ROLE, owner);
+        _grantRole(UPGRADER_ROLE, owner);
+
+        ComponentTokenStorage storage $ = _getComponentTokenStorage();
+        $.asyncDeposit = asyncDeposit;
+        $.asyncRedeem = asyncRedeem;
+    }
+
     // Override Functions
 
     /**

--- a/nest/test/pUSD.t.sol
+++ b/nest/test/pUSD.t.sol
@@ -239,7 +239,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         assertNotEq(token.version(), 1);
@@ -253,7 +255,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         vm.expectRevert(BoringVaultAdapter.ZeroAddress.selector);
@@ -265,7 +269,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         vm.expectRevert(BoringVaultAdapter.ZeroAddress.selector);
@@ -276,7 +282,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         vm.expectRevert(BoringVaultAdapter.ZeroAddress.selector);
@@ -287,7 +295,9 @@ contract pUSDTest is Test {
             address(0),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         vm.expectRevert(BoringVaultAdapter.ZeroAddress.selector);
@@ -298,7 +308,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(0),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
     }
 
@@ -416,7 +428,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         // Now we can test the preview functions with the new vault
@@ -441,7 +455,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         // Now we can test the preview functions with the new vault
@@ -480,7 +496,9 @@ contract pUSDTest is Test {
             address(mockTeller),
             address(mockAtomicQueue),
             address(mockLens),
-            address(mockAccountant)
+            address(mockAccountant),
+            "Plume USD",
+            "pUSD"
         );
 
         // Test convertToShares revert


### PR DESCRIPTION
## What's new in this PR?

We have to call `__ERC4626_init(asset_)` to change the asset for the `BoringVaultAdapter`, so we need to add a reinitializer to `ComponentToken` too.

## Why?

What problem does this solve?
Why is this important?
What's the context?
