### PR TITLE
[PDE-457] make boringvaultadapter not asynchronously redeemable.

### DIFF
--- a/nest/src/token/BoringVaultAdapter.sol
+++ b/nest/src/token/BoringVaultAdapter.sol
@@ -129,7 +129,7 @@ abstract contract BoringVaultAdapter is
         }
 
         // Set async redeem to true
-        super.initialize(owner, name, symbol, asset_, false, true);
+        super.initialize(owner, name, symbol, asset_, false, false);
 
         BoringVaultAdapterStorage storage $ = _getBoringVaultAdapterStorage();
         $.boringVault.teller = ITeller(teller_);


### PR DESCRIPTION
## What's new in this PR?

The BoringVaultAdapter was asynchronously redeemable, should be redeemable synchronously.