### PR TITLE
[PDE-514] fix ottersec yieldtoken suggestions

### DIFF
--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -17,7 +17,7 @@ import { YieldDistributionToken } from "./YieldDistributionToken.sol";
 
 /**
  * @title YieldToken
- * @author Eugene Y. Q. Shen
+ * @author Eugene Y. Q. Shen, Alp Guneysel
  * @notice ERC20 token that receives yield redistributions from an AssetToken
  */
 contract YieldToken is YieldDistributionToken, ERC4626, WalletUtils, IYieldToken, IComponentToken {
@@ -334,9 +334,8 @@ contract YieldToken is YieldDistributionToken, ERC4626, WalletUtils, IYieldToken
             revert InsufficientRequestBalance(controller, assets, 1);
         }
 
-
-        // Use the pre-calculated shares amount from the notification
-        shares = $.sharesDepositRequest[controller];
+        // Calculate proportional shares based on requested assets
+        shares = $.sharesDepositRequest[controller].mulDivDown(assets, $.claimableDepositRequest[controller]);
 
         $.claimableDepositRequest[controller] -= assets;
         $.sharesDepositRequest[controller] -= shares;
@@ -439,8 +438,8 @@ contract YieldToken is YieldDistributionToken, ERC4626, WalletUtils, IYieldToken
             revert InsufficientRequestBalance(controller, shares, 3);
         }
 
-    // Use the pre-calculated assets amount from the notification
-    assets = $.assetsRedeemRequest[controller];
+        // Calculate proportional assets based on requested shares
+        assets = $.assetsRedeemRequest[controller].mulDivDown(shares, $.claimableRedeemRequest[controller]);
 
         $.claimableRedeemRequest[controller] -= shares;
         $.assetsRedeemRequest[controller] -= assets;
@@ -474,12 +473,9 @@ contract YieldToken is YieldDistributionToken, ERC4626, WalletUtils, IYieldToken
         if (assets > $.assetsRedeemRequest[controller]) {
             revert InsufficientRequestBalance(controller, assets, 3);
         }
-        
+
         // Calculate proportional shares based on requested assets
-        shares = $.claimableRedeemRequest[controller].mulDivDown(
-            assets, 
-            $.assetsRedeemRequest[controller]
-        );
+        shares = $.claimableRedeemRequest[controller].mulDivDown(assets, $.assetsRedeemRequest[controller]);
 
         $.claimableRedeemRequest[controller] -= shares;
         $.assetsRedeemRequest[controller] -= assets;


### PR DESCRIPTION
## What's new in this PR?

- It seems that the current YieldToken defines custom implementations for convertToShares and convertToAssets, but it hasn't overridden some functions in ERC4626 that depend on these (maxWithdraw, previewDeposit, previewMint, previewWithdraw, previewRedeem). We also observed that mint and deposit defined in ERC4626 can still be used here, which depend on the original implementation of conversion logic.
- In the current definition of YieldToken, it seems that when the super keyword is used, ERC4626 is prioritized over YieldDistributionToken. Due to this, the decimals() function will use the definition from ERC4626 instead of YieldDistributionToken.
- In the current deposit function, it seems that regardless of the assets amount that is passed, the number of shares being minted will be the maximum stored in the mapping. The same behavior occurs in the redeem function with respect to shares.
- It seems that there is a possible discrepancy between assets and shares during mint & withdraw because the conversion rate may differ between the request and process times, which can cause the function to revert when checking if the conversion result is higher than the requested value.
