### PR TITLE
[PDE-668] ottersec final fixes

### DIFF
--- a/nest/src/AggregateToken.sol
+++ b/nest/src/AggregateToken.sol
@@ -160,20 +160,24 @@ contract AggregateToken is ComponentToken, IAggregateToken, ERC1155Holder {
     /**
      * @inheritdoc IERC4626
      * @dev 1:1 conversion rate between USDT and base asset
+     * @dev Always round DOWN for convertToShares for user safety
      */
     function convertToShares(
         uint256 assets
     ) public view override(ComponentToken, IComponentToken) returns (uint256 shares) {
+        // Division rounds down by default
         return assets * _BASE / _getAggregateTokenStorage().askPrice;
     }
 
     /**
      * @inheritdoc IERC4626
      * @dev 1:1 conversion rate between USDT and base asset
+     * @dev Always round DOWN for convertToAssets for user safety
      */
     function convertToAssets(
         uint256 shares
     ) public view override(ComponentToken, IComponentToken) returns (uint256 assets) {
+        // Division rounds down by default
         return shares * _getAggregateTokenStorage().bidPrice / _BASE;
     }
 

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -419,8 +419,8 @@ abstract contract ComponentToken is
             $.claimableDepositRequest[controller] = 0;
             $.sharesDepositRequest[controller] = 0;
         } else {
-            SafeERC20.safeTransferFrom(IERC20(asset()), controller, address(this), assets);
             shares = convertToShares(assets);
+            SafeERC20.safeTransferFrom(IERC20(asset()), controller, address(this), assets);
         }
 
         _mint(receiver, shares);

--- a/nest/src/ComponentToken.sol
+++ b/nest/src/ComponentToken.sol
@@ -558,8 +558,8 @@ abstract contract ComponentToken is
             $.assetsRedeemRequest[controller] = 0;
         } else {
             // For sync redemptions, process normally
-            _burn(controller, shares);
             assets = convertToAssets(shares);
+            _burn(controller, shares);
         }
 
         SafeERC20.safeTransfer(IERC20(asset()), receiver, assets);

--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -290,7 +290,10 @@ contract YieldToken is
         return convertToAssets(balanceOf(owner));
     }
 
-    /// @inheritdoc IERC4626
+    /**
+     * @inheritdoc IERC4626
+     * @dev Always rounds down for user safety when converting assets to shares
+     */
     function convertToShares(
         uint256 assets
     ) public view override(ERC4626Upgradeable, IComponentToken) returns (uint256 shares) {
@@ -302,7 +305,10 @@ contract YieldToken is
         return (assets * supply) / totalAssets_;
     }
 
-    /// @inheritdoc IERC4626
+    /**
+     * @inheritdoc IERC4626
+     * @dev Always rounds down for user safety when converting shares to assets
+     */
     function convertToAssets(
         uint256 shares
     ) public view override(ERC4626Upgradeable, IComponentToken) returns (uint256 assets) {

--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -491,7 +491,6 @@ contract YieldToken is
 
         YieldTokenStorage storage $ = _getYieldTokenStorage();
 
-        //_burn(msg.sender, shares);
         $.pendingRedeemRequest[controller] += shares;
 
         emit RedeemRequest(controller, owner, REQUEST_ID, owner, shares);

--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -479,7 +479,7 @@ contract YieldToken is
 
         YieldTokenStorage storage $ = _getYieldTokenStorage();
 
-        _burn(msg.sender, shares);
+        //_burn(msg.sender, shares);
         $.pendingRedeemRequest[controller] += shares;
 
         emit RedeemRequest(controller, owner, REQUEST_ID, owner, shares);
@@ -539,7 +539,11 @@ contract YieldToken is
         // Track managed assets
         $.totalManagedAssets -= assets;
 
-        _beforeWithdraw(assets); // Add this line to check yield buffer
+        // Check yield buffer
+        _beforeWithdraw(assets); 
+
+        // Burn the shares, when we actually process the redemption
+        _burn(controller, shares);
 
         if (!IERC20(asset()).transfer(receiver, assets)) {
             revert InsufficientBalance(IERC20(asset()), address(this), assets);

--- a/smart-wallets/src/token/YieldToken.sol
+++ b/smart-wallets/src/token/YieldToken.sol
@@ -539,6 +539,8 @@ contract YieldToken is
         // Track managed assets
         $.totalManagedAssets -= assets;
 
+        _beforeWithdraw(assets); // Add this line to check yield buffer
+
         if (!IERC20(asset()).transfer(receiver, assets)) {
             revert InsufficientBalance(IERC20(asset()), address(this), assets);
         }


### PR DESCRIPTION
## What's new in this PR?

- It seems that YieldToken::mint hasn't been updated yet to follow the new conversion logic.
- It seems that YieldToken::redeem hasn't done yieldBuffer check like withdraw yet.

- Just to be safer, would it make sense to properly implement the rounding direction that you added in ComponentToken comments to the inherited contracts like AggregateToken? It would be better to do this in YieldToken as well just to be safe.

- For the synchronous redeem in ComponentToken, it seems that the convertToAssets should be called before calling _burn because otherwise it will incorrectly inflate the shares value if the overridden convertToAssets depends on totalSupply.

-  the same issue applies to the synchronous ComponentToken::deposit as well, where transferring the asset should happen after the calculation. In general, we suggest that for actions that might change the value of totalSupply or totalAssets in ERC4626, all calculations should be done before making those changes. Thanks all!

- For the asynchronous redeem logic in YieldToken, how will you handle the _notifyRedeem conversion rate to be precise?

- For example, we observed that when users call requestRedeem, the shares will be burned first, which means that the conversion rate in the on-chain side will be inflated until the request is executed (either via withdraw or redeem).
- Similarly, this applies to future contracts that want to inherit ComponentToken with async features enabled and has dependencies on totalSupply during the conversion logic.