### PR TITLE
[PDE-830] PlumeStaking improvements

### DIFF
--- a/p/src/PlumeStaking.sol
+++ b/p/src/PlumeStaking.sol
@@ -453,4 +453,5 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
             amount += (info.staked * (block.timestamp - info.lastUpdateTimestamp) * $.perSecondRewardRate) / _BASE;
         }
     }
+
 }

--- a/p/src/PlumeStaking.sol
+++ b/p/src/PlumeStaking.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.25;
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
@@ -217,35 +217,35 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
 
     /**
      * @notice Set the minimum amount of $PLUME that can be staked
-     * @param minStakeAmount Minimum amount of $PLUME that can be staked
+     * @param minStakeAmount_ Minimum amount of $PLUME that can be staked
      */
     function setMinStakeAmount(
-        uint256 minStakeAmount
+        uint256 minStakeAmount_
     ) external onlyRole(ADMIN_ROLE) nonReentrant {
-        _getPlumeStakingStorage().minStakeAmount = minStakeAmount;
-        emit SetMinStakeAmount(minStakeAmount);
+        _getPlumeStakingStorage().minStakeAmount = minStakeAmount_;
+        emit SetMinStakeAmount(minStakeAmount_);
     }
 
     /**
      * @notice Set the cooldown interval for staked assets to be unlocked and parked
-     * @param cooldownInterval Cooldown interval for staked assets to be unlocked and parked
+     * @param cooldownInterval_ Cooldown interval for staked assets to be unlocked and parked
      */
     function setCooldownInterval(
-        uint256 cooldownInterval
+        uint256 cooldownInterval_
     ) external onlyRole(ADMIN_ROLE) nonReentrant {
-        _getPlumeStakingStorage().cooldownInterval = cooldownInterval;
-        emit SetCooldownInterval(cooldownInterval);
+        _getPlumeStakingStorage().cooldownInterval = cooldownInterval_;
+        emit SetCooldownInterval(cooldownInterval_);
     }
 
     /**
      * @notice Set the rate of $pUSD rewarded per $PLUME staked per second
-     * @param perSecondRewardRate Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
+     * @param perSecondRewardRate_ Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
      */
     function setPerSecondRewardRate(
-        uint256 perSecondRewardRate
+        uint256 perSecondRewardRate_
     ) external onlyRole(ADMIN_ROLE) nonReentrant {
-        _getPlumeStakingStorage().perSecondRewardRate = perSecondRewardRate;
-        emit SetPerSecondRewardRate(perSecondRewardRate);
+        _getPlumeStakingStorage().perSecondRewardRate = perSecondRewardRate_;
+        emit SetPerSecondRewardRate(perSecondRewardRate_);
     }
 
     // User Functions
@@ -421,7 +421,7 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
      */
     function stakeInfo(
         address user
-    ) external view returns (StakeInfo info) {
+    ) external view returns (StakeInfo memory info) {
         info = _getPlumeStakingStorage().stakeInfo[user];
     }
 

--- a/p/src/PlumeStaking.sol
+++ b/p/src/PlumeStaking.sol
@@ -179,7 +179,7 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         $.pUSD = IERC20(pUSD);
         $.minStakeAmount = 1e18;
         $.cooldownInterval = 7 days;
-        $.perSecondRewardRate = _BASE * 0.05 * 0.12;
+        $.perSecondRewardRate = (_BASE * 5 * 12) / (100 * 100);
 
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
         _grantRole(ADMIN_ROLE, owner);
@@ -207,14 +207,8 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     ) internal {
         PlumeStakingStorage storage s = _getPlumeStakingStorage();
         StakeInfo storage info = s.stakeInfo[user];
-        info = StakeInfo({
-            staked: info.staked,
-            parked: info.parked,
-            cooled: info.cooled,
-            cooldownEnd: info.cooldownEnd,
-            accumulatedRewards: claimableBalance(user),
-            lastUpdateTimestamp: block.timestamp
-        });
+        info.accumulatedRewards = claimableBalance(user);
+        info.lastUpdateTimestamp = block.timestamp;
     }
 
     // Admin Functions

--- a/p/src/PlumeStaking.sol
+++ b/p/src/PlumeStaking.sol
@@ -4,8 +4,9 @@ pragma solidity ^0.8.25;
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import { Plume } from "./Plume.sol";
 
@@ -14,11 +15,7 @@ import { Plume } from "./Plume.sol";
  * @author Eugene Y. Q. Shen
  * @notice Staking contract for $PLUME
  */
-contract PlumeStaking is
-    Initializable,
-    AccessControlUpgradeable,
-    UUPSUpgradeable
-{
+contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
 
     // Storage
 
@@ -119,7 +116,7 @@ contract PlumeStaking is
 
     // Errors
 
-    /** 
+    /**
      * @notice Indicates a failure because the amount is invalid
      * @param amount Amount of $PLUME requested
      * @param minStakeAmount Minimum amount of $PLUME allowed
@@ -168,11 +165,7 @@ contract PlumeStaking is
      * @dev Give all roles to the admin address passed into the constructor
      * @param owner Address of the owner of PlumeStaking
      */
-    function initialize(
-        address owner,
-        address plume_,
-        address pUSD
-    ) public initializer {
+    function initialize(address owner, address plume_, address pUSD) public initializer {
         __AccessControl_init();
         __UUPSUpgradeable_init();
 
@@ -203,7 +196,9 @@ contract PlumeStaking is
      * @notice Park $PLUME in the contract
      * @param amount Amount of $PLUME to park
      */
-    function park(uint256 amount) external {
+    function park(
+        uint256 amount
+    ) external {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         if (amount < $.minStakeAmount) {
             revert InvalidAmount(amount, $.minStakeAmount);
@@ -214,7 +209,7 @@ contract PlumeStaking is
 
         emit Parked(msg.sender, amount);
     }
-    
+
     /**
      * @notice Stake $PLUME in the contract
      * @dev TODO unlockTime == 0 for auto-extending staking
@@ -230,9 +225,8 @@ contract PlumeStaking is
             revert InvalidAmount(amount, $.minStakeAmount);
         }
         if (
-            ($.unlockTime[msg.sender] != 0 && timestamp != $.unlockTime[msg.sender])
-            || timestamp <= block.timestamp 
-            || timestamp > block.timestamp + $.maxStakeInterval
+            ($.unlockTime[msg.sender] != 0 && timestamp != $.unlockTime[msg.sender]) || timestamp <= block.timestamp
+                || timestamp > block.timestamp + $.maxStakeInterval
         ) {
             revert InvalidUnlockTime();
         }
@@ -264,9 +258,8 @@ contract PlumeStaking is
             revert InvalidAmount(amount, $.minStakeAmount);
         }
         if (
-            ($.unlockTime[msg.sender] != 0 && timestamp != $.unlockTime[msg.sender])
-            || timestamp <= block.timestamp 
-            || timestamp > block.timestamp + $.maxStakeInterval
+            ($.unlockTime[msg.sender] != 0 && timestamp != $.unlockTime[msg.sender]) || timestamp <= block.timestamp
+                || timestamp > block.timestamp + $.maxStakeInterval
         ) {
             revert InvalidUnlockTime();
         }
@@ -285,7 +278,9 @@ contract PlumeStaking is
      * @notice Extend the unlock time for the staked assets
      * @param timestamp New timestamp at which the assets at stake unlock
      */
-    function extendTime(uint256 timestamp) external {
+    function extendTime(
+        uint256 timestamp
+    ) external {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         if ($.cooldownEnd[msg.sender] > block.timestamp) {
             revert CooldownPeriodNotEnded($.cooldownEnd[msg.sender]);
@@ -325,7 +320,9 @@ contract PlumeStaking is
      * @notice Unpark $PLUME from the contract
      * @param amount Amount of $PLUME to unpark
      */
-    function unpark(uint256 amount) external {
+    function unpark(
+        uint256 amount
+    ) external {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         if ($.cooled[msg.sender] > 0 && $.cooldownEnd[msg.sender] >= block.timestamp) {
             $.parked[msg.sender] += $.cooled[msg.sender];
@@ -345,7 +342,9 @@ contract PlumeStaking is
      * @notice Claim $PLUME
      * @param amount Amount of $PLUME to claim
      */
-    function claimPlume(uint256 amount) external {
+    function claimPlume(
+        uint256 amount
+    ) external {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         $.claimablePlume[msg.sender] = claimablePlumeBalance(msg.sender);
         if (amount > $.claimablePlume[msg.sender]) {
@@ -362,7 +361,9 @@ contract PlumeStaking is
      * @notice Claim $pUSD
      * @param amount Amount of $pUSD to claim
      */
-    function claimStable(uint256 amount) external {
+    function claimStable(
+        uint256 amount
+    ) external {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         $.claimableStable[msg.sender] = claimableStableBalance(msg.sender);
         if (amount > $.claimableStable[msg.sender]) {
@@ -402,7 +403,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $PLUME staked by the user
      */
-    function staked(address user) external view returns (uint256) {
+    function staked(
+        address user
+    ) external view returns (uint256) {
         return _getPlumeStakingStorage().staked[user];
     }
 
@@ -411,7 +414,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $PLUME parked by the user
      */
-    function parked(address user) external view returns (uint256) {
+    function parked(
+        address user
+    ) external view returns (uint256) {
         return _getPlumeStakingStorage().parked[user];
     }
 
@@ -420,7 +425,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $PLUME awaiting cooldown by the user
      */
-    function cooled(address user) external view returns (uint256) {
+    function cooled(
+        address user
+    ) external view returns (uint256) {
         return _getPlumeStakingStorage().cooled[user];
     }
 
@@ -429,7 +436,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return timestamp Timestamp at which the assets at stake unlock
      */
-    function unlockTime(address user) external view returns (uint256) {
+    function unlockTime(
+        address user
+    ) external view returns (uint256) {
         return _getPlumeStakingStorage().unlockTime[user];
     }
 
@@ -438,7 +447,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return timestamp Timestamp at which the cooldown period ends
      */
-    function cooldownEnd(address user) external view returns (uint256) {
+    function cooldownEnd(
+        address user
+    ) external view returns (uint256) {
         return _getPlumeStakingStorage().cooldownEnd[user];
     }
 
@@ -447,7 +458,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $PLUME available to unpark
      */
-    function withdrawableBalance(address user) external view returns (uint256 amount) {
+    function withdrawableBalance(
+        address user
+    ) external view returns (uint256 amount) {
         PlumeStakingStorage storage $ = _getPlumeStakingStorage();
         amount = $.parked[user];
         if ($.cooled[user] > 0 && $.cooldownEnd[user] >= block.timestamp) {
@@ -460,7 +473,9 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $PLUME available to claim
      */
-    function claimablePlumeBalance(address user) public view returns (uint256 amount) {
+    function claimablePlumeBalance(
+        address user
+    ) public view returns (uint256 amount) {
         amount = _getPlumeStakingStorage().claimablePlume[user];
         // TODO additional calculation here
     }
@@ -470,8 +485,11 @@ contract PlumeStaking is
      * @param user Address of the user
      * @return amount Amount of $pUSD available to claim
      */
-    function claimableStableBalance(address user) public view returns (uint256 amount) {
+    function claimableStableBalance(
+        address user
+    ) public view returns (uint256 amount) {
         amount = _getPlumeStakingStorage().claimableStable[user];
         // TODO additional calculation here
     }
+
 }

--- a/p/src/PlumeStaking.sol
+++ b/p/src/PlumeStaking.sol
@@ -34,8 +34,8 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         uint256 maxStakeInterval;
         /// @dev Cooldown interval for unstaked assets to be unlocked and parked
         uint256 cooldownInterval;
-        /// @dev Rate of $pUSD rewarded per $PLUME staked per year, scaled by _BASE
-        uint256 annualRewardRate;
+        /// @dev Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
+        uint256 perSecondRewardRate;
         /// @dev Amount of $PLUME deposited but not staked by each user
         mapping(address user => uint256 amount) parked;
         /// @dev Amount of $PLUME that are in cooldown (unstaked but not yet withdrawable)
@@ -101,10 +101,10 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     event SetCooldownInterval(uint256 cooldownInterval);
 
     /**
-     * @notice Emitted when the rate of $pUSD rewarded per $PLUME staked per year is set
-     * @param annualRewardRate Rate of $pUSD rewarded per $PLUME staked per year, scaled by _BASE
+     * @notice Emitted when the rate of $pUSD rewarded per $PLUME staked per second is set
+     * @param perSecondRewardRate Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
      */
-    event SetAnnualRewardRate(uint256 annualRewardRate);
+    event SetPerSecondRewardRate(uint256 perSecondRewardRate);
 
     /**
      * @notice Emitted when a user parks $PLUME
@@ -218,7 +218,7 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         $.minStakeAmount = 1e18;
         $.maxStakeInterval = 365 * 4 + 1 days;
         $.cooldownInterval = 7 days;
-        $.annualRewardRate = 1e18 + 1e18 * 0.05 * 0.12;
+        $.perSecondRewardRate = 1e18 * 0.05 * 0.12;
 
         _grantRole(DEFAULT_ADMIN_ROLE, owner);
         _grantRole(ADMIN_ROLE, owner);
@@ -271,14 +271,14 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
     }
 
     /**
-     * @notice Set the rate of $pUSD rewarded per $PLUME staked per year
-     * @param annualRewardRate Rate of $pUSD rewarded per $PLUME staked per year, scaled by _BASE
+     * @notice Set the rate of $pUSD rewarded per $PLUME staked per second
+     * @param perSecondRewardRate Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
      */
-    function setAnnualRewardRate(
-        uint256 annualRewardRate
+    function setPerSecondRewardRate(
+        uint256 perSecondRewardRate
     ) external onlyRole(ADMIN_ROLE) nonReentrant {
-        _getPlumeStakingStorage().annualRewardRate = annualRewardRate;
-        emit SetAnnualRewardRate(annualRewardRate);
+        _getPlumeStakingStorage().perSecondRewardRate = perSecondRewardRate;
+        emit SetPerSecondRewardRate(perSecondRewardRate);
     }
 
     // User Functions
@@ -489,9 +489,9 @@ contract PlumeStaking is Initializable, AccessControlUpgradeable, UUPSUpgradeabl
         return _getPlumeStakingStorage().cooldownInterval;
     }
 
-    /// @notice Rate of $pUSD rewarded per $PLUME staked per year, scaled by _BASE
-    function annualRewardRate() external view returns (uint256) {
-        return _getPlumeStakingStorage().annualRewardRate;
+    /// @notice Rate of $pUSD rewarded per $PLUME staked per second, scaled by _BASE
+    function perSecondRewardRate() external view returns (uint256) {
+        return _getPlumeStakingStorage().perSecondRewardRate;
     }
 
     /**


### PR DESCRIPTION
## What's new in this PR?

- Remove `unlockTime`, `maxStakeInterval`, and `extendTime()` as users can stake and unstake at any time, without specifying a lockup period.
- Remove $PLUME rewards for $PLUME staking. All rewards can be paid out in $pUSD.
- Move all other user-related variables into a single struct per user.
- Add various improvements from #164 to avoid merge conflicts.

## Why?

What problem does this solve?
Why is this important?
What's the context?
