### PR TITLE
SPIN-1, SPIN-3, SPIN-4, SPIN-7 fixes

### DIFF
--- a/plume/src/spin/Raffle.sol
+++ b/plume/src/spin/Raffle.sol
@@ -282,65 +282,6 @@ contract Raffle is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         emit PrizeClaimed(msg.sender, prizeId);
     }
 
-    // Return the data for all prizes for a user, including the prizes themselves
-    // the prizes, how much they spent on each, and how many unclaimed and claimed wins they have
-    function getUserEntries(address user) external view returns (
-        uint256[] memory _prizeIds,
-        uint256[] memory ticketCounts,
-        uint256[] memory unclaimedWinnings,
-        uint256[] memory claimedWinnings
-    ) {
-        uint256 count = prizeIds.length;
-        _prizeIds = new uint256[](count);
-        ticketCounts = new uint256[](count);
-        
-        // Count winners first to allocate arrays correctly
-        uint256 unclaimedCount = 0;
-        uint256 claimedCount = 0;
-        for (uint256 i = 0; i < count; i++) {
-            uint256 prizeId = prizeIds[i];
-            Prize storage prize = prizes[prizeId];
-            if (prize.winner == user) {
-                if (prize.claimed) {
-                    claimedCount++;
-                } else {
-                    unclaimedCount++;
-                }
-            }
-        }
-        
-        unclaimedWinnings = new uint256[](unclaimedCount);
-        claimedWinnings = new uint256[](claimedCount);
-        unclaimedCount = 0;  // Reset for reuse
-        claimedCount = 0;    // Reset for reuse
-
-        // Copy prize IDs and process each prize
-        for (uint256 i = 0; i < count; i++) {
-            uint256 prizeId = prizeIds[i];
-            _prizeIds[i] = prizeId;
-            
-            // Calculate tickets spent
-            Range[] storage ranges = prizeRanges[prizeId];
-            for (uint256 j = 0; j < ranges.length; j++) {
-                if (ranges[j].user == user) {
-                    uint256 prevEnd = (j == 0) ? 0 : ranges[j - 1].cumulativeEnd;
-                    ticketCounts[i] += ranges[j].cumulativeEnd - prevEnd;
-                }
-            }
-            
-            // Track winnings
-            Prize storage prize = prizes[prizeId];
-            if (prize.winner == user) {
-                if (prize.claimed) {
-                    claimedWinnings[claimedCount++] = prizeId;
-                } else {
-                    unclaimedWinnings[unclaimedCount++] = prizeId;
-                }
-            }
-        }
-
-        return (_prizeIds, ticketCounts, unclaimedWinnings, claimedWinnings);
-    }
 
     function getPrizeIds() external view returns (uint256[] memory) {
         return prizeIds;

--- a/plume/src/spin/Spin.sol
+++ b/plume/src/spin/Spin.sol
@@ -23,11 +23,12 @@ contract Spin is Initializable, AccessControlUpgradeable, UUPSUpgradeable, Pausa
         uint256 nothingCounts;
     }
 
+    // Defines the probability ranges for non-jackpot rewards based on a 0-999,999 scale.
+    // Jackpot probability is determined separately by the daily jackpotProbabilities array.
     struct RewardProbabilities {
-        uint256 jackpotThreshold;    // 0 to jackpotThreshold
-        uint256 plumeTokenThreshold; // jackpotThreshold to plumeTokenThreshold
-        uint256 raffleTicketThreshold; // plumeTokenThreshold to raffleTicketThreshold
-        uint256 ppThreshold;         // raffleTicketThreshold to ppThreshold
+        uint256 plumeTokenThreshold; // Range start depends on daily jackpot threshold, ends here.
+        uint256 raffleTicketThreshold; // Starts after plumeTokenThreshold, ends here.
+        uint256 ppThreshold;         // Starts after raffleTicketThreshold, ends here.
         // anything above ppThreshold is "Nothing"
     }
 
@@ -114,12 +115,12 @@ contract Spin is Initializable, AccessControlUpgradeable, UUPSUpgradeable, Pausa
         lastJackpotClaimWeek = 999;  // start with arbitrary non-zero value
 
         // Set default probabilities
+        // Note: Jackpot probability is handled by jackpotProbabilities based on dayOfWeek
         rewardProbabilities = RewardProbabilities({
-            jackpotThreshold: 200,        // 0-200 (0.02% but further modified by the daily odds to much lower)
-            plumeTokenThreshold: 200_000,  // 201-200,000 (20%)
-            raffleTicketThreshold: 600_000, // 200,001-600,000 (40%)
-            ppThreshold: 900_000           // 600,001-900,000 (30%)
-                                           // 900,001-1,000,000 is "Nothing" (10%)
+            plumeTokenThreshold: 200_000,  // Up to 200,000 (Approx 20%)
+            raffleTicketThreshold: 600_000, // Up to 600,000 (Approx 40%)
+            ppThreshold: 900_000           // Up to 900,000 (Approx 30%)
+                                           // Above 900,000 is "Nothing" (Approx 10%)
         });
     }
 

--- a/plume/test/Raffle.t.sol
+++ b/plume/test/Raffle.t.sol
@@ -359,18 +359,7 @@ contract RaffleFlowTest is PlumeTestBase {
         vm.prank(USER); raffle.spendRaffle(1,2);
         vm.prank(USER); raffle.spendRaffle(1,1);
 
-        // getUserEntries(user) - check initial state
-        (
-            uint256[] memory ids, 
-            uint256[] memory counts, 
-            uint256[] memory unclaimedWins,
-            uint256[] memory claimedWins
-        ) = raffle.getUserEntries(USER);
-        
-        assertEq(ids.length, 1);
-        assertEq(counts[0], 3);  // 2 + 1 tickets spent
-        assertEq(unclaimedWins.length, 0);
-        assertEq(claimedWins.length, 0);
+   
 
         // draw and claim so wins get populated
         vm.recordLogs();
@@ -396,23 +385,11 @@ contract RaffleFlowTest is PlumeTestBase {
         vm.prank(ADMIN);
         raffle.setWinner(1);
 
-        // Check unclaimed wins before claiming
-        (ids, counts, unclaimedWins, claimedWins) = raffle.getUserEntries(USER);
-        assertEq(unclaimedWins.length, 1);
-        assertEq(unclaimedWins[0], 1);
-        assertEq(claimedWins.length, 0);
 
         // Claim the prize
         vm.prank(USER); 
         raffle.claimPrize(1);
 
-        // Check claimed wins after claiming
-        (ids, counts, unclaimedWins, claimedWins) = raffle.getUserEntries(USER);
-        assertEq(ids.length, 1);
-        assertEq(counts[0], 3);
-        assertEq(unclaimedWins.length, 0);
-        assertEq(claimedWins.length, 1);
-        assertEq(claimedWins[0], 1);
     }
 
     // Test that getWinner returns the correct winner

--- a/plume/test/Spin.t.sol
+++ b/plume/test/Spin.t.sol
@@ -163,24 +163,28 @@ contract SpinTest is SpinTestBase {
 
         // Spin day 1
         uint256 ts1 = block.timestamp;
-        uint256 nonce = performSpin(USER);
-        completeSpin(nonce, 999_999);
+        uint256 nonce1 = performSpin(USER); // Nonce for day 1
+        completeSpin(nonce1, 999_999);      // Complete spin for day 1
         // after first spin, streak = 1
         assertEq(spin.currentStreak(USER), 1);
 
-        // Next day
+        // Next day (Day 2)
         vm.warp(ts1 + 1 days);
-        // next day, no spin yet, streak = 1
+        // next day, no spin yet, streak = 1 (correctly reflects last spin's effect)
         assertEq(spin.currentStreak(USER), 1);
-        completeSpin(nonce, 999_999);
+        // Spin again on Day 2
+        uint256 nonce2 = performSpin(USER); // Nonce for day 2
+        completeSpin(nonce2, 999_999);      // Complete spin for day 2
         // next day, spin again, streak = 2
         assertEq(spin.currentStreak(USER), 2);
 
-        // Skip a day
+        // Skip a day (Go to Day 4)
         vm.warp(ts1 + 3 days);
-        // skip a day, no spin yet, streak = 0
+        // skip a day, no spin yet, streak = 0 (broken streak)
         assertEq(spin.currentStreak(USER), 0);
-        completeSpin(nonce, 999_999);
+        // Spin again on Day 4
+        uint256 nonce3 = performSpin(USER); // Nonce for day 4
+        completeSpin(nonce3, 999_999);      // Complete spin for day 4
         // skip a day, spin again, streak = 1
         assertEq(spin.currentStreak(USER), 1);
     }


### PR DESCRIPTION
## What's new in this PR?

**SPIN-1**
Users can spin as many times as they want: lastSpinTimestamp updates after the randomness callback, allowing multiple calls to startSpin as long as the callback has not been called yet by Supra.
**SPIN-2**
rewardProbabilities.jackpotThreshold appears unused, that means the calculation of the chances for getting a jackpot is solely based on jackpotProbabilities which is quite low.
**SPIN-3**
The check for whether a prizeId is in use fails if the name is an empty string - allowing overwrite. require(bytes(prizes[prizeId].name).length == 0, "Prize ID already in use"); won't indicate the prize is actually in use.
**SPIN-4**
Same as Spin-1, requestWinner in Raffle can be called multiple times before the callback handleWinnerSelection is called, creating multiple randomness requests and potentially overwriting the winner.
**SPIN-5**
If _safeTransferPlume reverts, there’s no retry mechanism. This may be acceptable behavior, but it could lead to lost rewards. 
**SPIN-6**
Spin doesn’t auto-end after 12 weeks. non-jackpot rewards can still be farmed.
**SPIN-7**
Reduntant modifier onlyAdmin, onlySupra modifiers in Raffle.sol.