### PR TITLE
[PDE-1092-15] fix inflated commission

### DIFF
--- a/plume/src/facets/StakingFacet.sol
+++ b/plume/src/facets/StakingFacet.sol
@@ -205,7 +205,13 @@ contract StakingFacet is ReentrancyGuardUpgradeable {
             PlumeRewardLogic.updateRewardsForValidator($, user, validatorId);
         }
 
-        // Update stake amount
+        // Initialize reward state for new stakes BEFORE updating stake amounts
+        // This ensures that commission calculations use the old totalStaked amount (before this user's stake)
+        if (isNewStake) {
+            _initializeRewardStateForNewStake(user, validatorId);
+        }
+
+        // Update stake amount AFTER reward state initialization
         _updateStakeAmounts(user, validatorId, stakeAmount);
 
         // Validate capacity limits
@@ -213,11 +219,6 @@ contract StakingFacet is ReentrancyGuardUpgradeable {
 
         // Add user to validator's staker list
         PlumeValidatorLogic.addStakerToValidator($, user, validatorId);
-
-        // Initialize reward state for new stakes
-        if (isNewStake) {
-            _initializeRewardStateForNewStake(user, validatorId);
-        }
     }
 
     /**


### PR DESCRIPTION
## What's new in this PR?

In the current _performStakeSetup function, for a new staking position, the code should update the validator reward state before updating the totalStaked amount. In the current code, when a user opens a new staking position, the validator will immediately get commission from that stake due to the usage of the new totalStaked amount instead of the old amount.
