### PR TITLE
[PDE-1092-16] fix RestakeValidatorRelationshipCleanup

### DIFF
--- a/plume/script/QueryDiamondState.s.sol
+++ b/plume/script/QueryDiamondState.s.sol
@@ -165,7 +165,7 @@ contract QueryDiamondState is Script {
             console2.log("  - cooled:", info.cooled);
             console2.log("  - parked:", info.parked);
             //console2.log("  - cooldownEnd:", info.cooldownEnd);
-            console2.log("  - lastUpdateTimestamp:", info.lastUpdateTimestamp);
+            //console2.log("  - lastUpdateTimestamp:", info.lastUpdateTimestamp);
         } catch Error(string memory reason) {
             if (keccak256(bytes(reason)) == PROXY_ERROR_HASH) {
                 console2.log("stakeInfo(SAMPLE_USER) FAILED: Proxy__ImplementationIsNotContract()");

--- a/plume/src/facets/StakingFacet.sol
+++ b/plume/src/facets/StakingFacet.sol
@@ -367,7 +367,7 @@ contract StakingFacet is ReentrancyGuardUpgradeable {
 
         // Clean up validator relationships for validators where cooling became 0
         for (uint256 i = 0; i < checkCount; i++) {
-            _cleanupValidatorRelationshipIfNeeded(user, validatorsToCheck[i]);
+            PlumeValidatorLogic.removeStakerFromValidator($, user, validatorsToCheck[i]);
         }
 
         // Emit events with proper fund source breakdown
@@ -1135,19 +1135,6 @@ contract StakingFacet is ReentrancyGuardUpgradeable {
                 PlumeValidatorLogic.removeStakerFromValidator($, user, validatorId);
             }
         }
-    }
-
-    /**
-     * @dev Cleans up validator relationship if needed
-     * @param user The user address
-     * @param validatorId The validator ID
-     */
-    function _cleanupValidatorRelationshipIfNeeded(address user, uint16 validatorId) internal {
-        PlumeStakingStorage.Layout storage $ = PlumeStakingStorage.layout();
-
-        // removeStakerFromValidator already checks for active stake, cooldown, and pending rewards
-        // Only call it if we know the conditions might be met (cooling amount is 0)
-        PlumeValidatorLogic.removeStakerFromValidator($, user, validatorId);
     }
 
 }


### PR DESCRIPTION
## What's new in this PR?

It seems that when using cooling amounts from other validators in the restake function, the validator relationship is not cleaned up when the cooled amount becomes 0 for that validator.
