### PR TITLE
allow edits for inactive prizes

### DIFF
--- a/plume/src/spin/Raffle.sol
+++ b/plume/src/spin/Raffle.sol
@@ -184,7 +184,7 @@ contract Raffle is Initializable, AccessControlUpgradeable, UUPSUpgradeable {
         uint256 value,
         uint256 quantity,
         string calldata formId
-    ) external onlyRole(ADMIN_ROLE) prizeIsActive(prizeId) {
+    ) external onlyRole(ADMIN_ROLE) {
         // Update prize details without affecting tickets or active status
         Prize storage prize = prizes[prizeId];
         prize.name = name;


### PR DESCRIPTION
prizes are immediately marked as inactive and thus uneditable once all users are drawn but we often have to make updates such, such as tally form id